### PR TITLE
fix bug where floating window requester hangs if no win under cursor …

### DIFF
--- a/src/zwm.c
+++ b/src/zwm.c
@@ -62,7 +62,7 @@
 	(SUBSTRUCTURE_REDIRECTION | XCB_EVENT_MASK_BUTTON_PRESS |             \
 	 XCB_EVENT_MASK_FOCUS_CHANGE | XCB_EVENT_MASK_ENTER_WINDOW)
 
-#define NUMBER_OF_DESKTOPS 5
+#define NUMBER_OF_DESKTOPS 7
 #define WM_NAME			   "zwm"
 #define WM_CLASS_NAME	   "null"
 #define WM_INSTANCE_NAME   "null"
@@ -2572,7 +2572,8 @@ handle_floating_window(client_t *client, desktop_t *d)
 	}
 
 	node_t *n = find_node_by_window_id(d->tree, wi);
-
+	// hacky approach in case win under cursor is not found
+	n		  = n == NULL ? find_left_leaf(d->tree) : n;
 	if (n == NULL || n->client == NULL) {
 		free(client);
 		_LOG_(ERROR, "cannot find node with window id %d", wi);


### PR DESCRIPTION
The get_window_under_cursor() function sometimes returns a window that is not stored in the tree, causing the floating window launcher to hang indefinitely while waiting for the window to be handled. To fix this, a random node is retrieved from the tree and used as the parent of the floating window.