### PR TITLE
Impliment multi-monitor support 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 CFLAGS = -Wall -Wextra -Wshadow -Wunreachable-code -Wcast-align -Wuninitialized
-LDFLAGS = -lxcb -lxcb-util -lxcb-keysyms -lxcb-ewmh -lxcb-icccm
+LDFLAGS = -lxcb -lxcb-util -lxcb-keysyms -lxcb-ewmh -lxcb-icccm -lxcb-randr -lxcb-xinerama 
 
 SRC_FILES = ./src/zwm.c ./src/logger.c ./src/tree.c ./src/config_parser.c
 HEADER_FILES = ./src/logger.h ./src/tree.h ./src/type.h ./src/zwm.h ./src/config_parser.h ./src/helper.h

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 CFLAGS = -Wall -Wextra -Wshadow -Wunreachable-code -Wcast-align -Wuninitialized
-LDFLAGS = -lxcb -lxcb-util -lxcb-keysyms -lxcb-ewmh -lxcb-icccm -lxcb-randr -lxcb-xinerama 
+LDFLAGS = -lxcb -lxcb-util -lxcb-keysyms -lxcb-ewmh -lxcb-icccm -lxcb-randr -lxcb-xinerama -lxcb-cursor
 
 SRC_FILES = ./src/zwm.c ./src/logger.c ./src/tree.c ./src/config_parser.c
 HEADER_FILES = ./src/logger.h ./src/tree.h ./src/type.h ./src/zwm.h ./src/config_parser.h ./src/helper.h

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ The motivation behind zwm stems from a desire to create a window manager that is
 - Compliance with a subset of [ewmh](https://specifications.freedesktop.org/wm-spec/wm-spec-1.3.html) and [icccm](https://www.x.org/releases/X11R7.6/doc/xorg-docs/specs/ICCCM/icccm.html) 
 - Multiple Layouts (default, master, stack, grid).
 - Multiple virtual desktops.
+- Multi-monitor support.
+- Independent workspaces for each monitor by default.
 - Low memory footprint, runs within ~2MB of memory
 - Resize, flip, and swap windows or partitions.
 - Layouts apply to individual desktops.
@@ -22,7 +24,7 @@ The motivation behind zwm stems from a desire to create a window manager that is
 - Customizable window rules.
 - Keyboard-Driven, fully controlled via keyboard shortcuts.
 - Can be integrated with any status bar.
-- Hot reload
+- Config reload on the fly.
 
 ## The underlying data structure:
 ZWM uses **binary space partitioning tree** ([BSP-tree](https://en.wikipedia.org/wiki/Binary_space_partitioning)) to store and manage windows. This allows for more flexible layouts.
@@ -125,6 +127,9 @@ ZWM uses **binary space partitioning tree** ([BSP-tree](https://en.wikipedia.org
 - xcb-util
 - xcb-util-keysyms
 - xcb-util-wm (ewmh,icccm)
+- lxcb-randr 
+- lxcb-xinerama 
+- lxcb-cursor
 ```
 git clone https://github.com/Yazeed1s/zwm.git
 cd zwm && sudo make install

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -39,10 +39,10 @@ extern rule_t  **_rules;
 extern int		 rule_index;
 
 // clang-format off
-int  load_config(config_t *c);
-void free_keys(void);
-void free_rules(void);
-int  reload_config(config_t *c);
 rule_t *get_window_rule(xcb_window_t win);
+int     load_config(config_t *c);
+void    free_keys(void);
+void    free_rules(void);
+int     reload_config(config_t *c);
 // clang-format on
 #endif // ZWM_CONFIG_PARSER_H

--- a/src/tree.c
+++ b/src/tree.c
@@ -1392,7 +1392,7 @@ hide_windows(node_t *cn)
 		}
 
 		if (!conf.focus_follow_pointer) {
-			grab_buttons(cn->client->window);
+			window_grab_buttons(cn->client->window);
 		}
 	}
 
@@ -2086,7 +2086,7 @@ update_focus(node_t *root, node_t *n)
 	if (flag && root != n) {
 		set_focus(root, false);
 		if (!conf.focus_follow_pointer)
-			grab_buttons(root->client->window);
+			window_grab_buttons(root->client->window);
 		root->is_focused = false;
 	}
 
@@ -2104,7 +2104,7 @@ update_focus_all(node_t *root)
 	if (flag) {
 		set_focus(root, false);
 		if (!conf.focus_follow_pointer)
-			grab_buttons(root->client->window);
+			window_grab_buttons(root->client->window);
 		root->is_focused = false;
 	}
 

--- a/src/tree.h
+++ b/src/tree.h
@@ -75,8 +75,7 @@ void	 resize_subtree(node_t *parent);
 void	 apply_layout(desktop_t *d, layout_t t);
 void	 free_tree(node_t *root);
 void	 restack(void);
-void
-restackv2(node_t *root);
+void     restackv2(node_t *root);
 void	 horizontal_resize(node_t *n, resize_t t);
 void	 delete_node(node_t *node, desktop_t *d);
 void	 insert_node(node_t *current_node, node_t *new_node, layout_t layout);
@@ -90,5 +89,6 @@ void	 transfer_node(node_t *, desktop_t *);
 int	     transfer_node_wrapper(arg_t *arg);
 int	     update_focused_node(node_t *root);
 int	     swap_node(node_t *root);
+void     update_focus_all(node_t *root);
 // clang-format on
 #endif // ZWM_TREE_H

--- a/src/type.h
+++ b/src/type.h
@@ -81,6 +81,16 @@ typedef enum {
 	WARNING
 } log_level_t;
 
+typedef enum {
+	CURSOR_POINTER = 0,
+	CURSOR_WATCH,
+	CURSOR_MOVE,
+	CURSOR_XTERM,
+	CURSOR_NOT_ALLOWED,
+	CURSOR_HAND2,
+	CURSOR_MAX
+} xcursor_cursor_t;
+
 typedef struct {
 	// 2^16 = 65535
 	uint16_t previous_x, previous_y;

--- a/src/type.h
+++ b/src/type.h
@@ -32,6 +32,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <sys/types.h>
+#include <xcb/randr.h>
 #include <xcb/xcb.h>
 #include <xcb/xcb_ewmh.h>
 
@@ -40,6 +41,8 @@
 #define MAXLEN				 (2 << 7)
 #define DLEN				 (2 << 4)
 #define NULL_STR			 "N/A"
+#define MONITOR_NAME		 "DEF_MONITOR"
+#define ROOT_WINDOW			 "root ZWM"
 #define NORMAL_BORDER_COLOR	 0x30302f
 #define ACTIVE_BORDER_COLOR	 0x83a598
 #define BORDER_WIDTH		 2
@@ -195,20 +198,35 @@ typedef struct {
 } desktop_t;
 
 typedef struct {
+	desktop_t		 **desktops;
+	char			   name[DLEN];
+	uint32_t		   id;
+	xcb_randr_output_t randr_id;
+	xcb_window_t	   root;
+	rectangle_t		   rectangle;
+	bool			   is_wired;
+	bool			   is_focused;
+	bool			   is_occupied;
+	bool			   is_primary;
+	uint8_t			   n_of_desktops;
+} monitor_t;
+
+typedef struct {
 	uint32_t	 id;
 	xcb_window_t window;
 	rectangle_t	 rectangle;
 } bar_t;
 
 typedef struct {
-	desktop_t			 **desktops;
+	monitor_t			 **monitors;
+	uint8_t				   n_of_monitors;
 	xcb_connection_t	  *connection;
 	xcb_ewmh_connection_t *ewmh;
 	xcb_screen_t		  *screen;
 	bar_t				  *bar;
 	xcb_window_t		   root_window;
 	split_type_t		   split_type;
-	uint8_t				   n_of_desktops;
+	// uint8_t				   n_of_desktops;
 	uint8_t				   screen_nbr;
 } wm_t;
 
@@ -252,6 +270,6 @@ typedef struct {
 typedef struct {
 	char	win_name[256];
 	state_t state;
-	int desktop_id;
+	int		desktop_id;
 } rule_t;
 #endif // ZWM_TYPE_H

--- a/src/zwm.c
+++ b/src/zwm.c
@@ -766,6 +766,16 @@ reload_config_wrapper()
 	uint32_t prev_normal_border_color = conf.normal_border_color;
 	int		 prev_virtual_desktops	  = conf.virtual_desktops;
 
+	memset(&conf, 0, sizeof(config_t));
+
+	ungrab_keys(wm->connection, wm->root_window);
+	is_kgrabbed = false;
+	free_keys();
+	free_rules();
+	assert(conf_keys == NULL && _rules == NULL);
+	_entries_  = 0;
+	rule_index = 0;
+
 	if (reload_config(&conf) != 0) {
 		_LOG_(ERROR,
 			  "Error while reloading config -> using default macros");
@@ -777,16 +787,6 @@ reload_config_wrapper()
 		conf.focus_follow_pointer = FOCUS_FOLLOW_POINTER;
 		return 0;
 	}
-
-	memset(&conf, 0, sizeof(config_t));
-
-	ungrab_keys(wm->connection, wm->root_window);
-	is_kgrabbed = false;
-	free_keys();
-	free_rules();
-	assert(conf_keys == NULL && _rules == NULL);
-	_entries_  = 0;
-	rule_index = 0;
 
 	bool color_changed =
 		(prev_normal_border_color != conf.normal_border_color) ||
@@ -3401,8 +3401,8 @@ handle_floating_window(client_t *client, desktop_t *d)
 		return -1;
 	}
 
-	int			x  = (wm->screen->width_in_pixels / 2) - (g->width / 2);
-	int			y  = (wm->screen->height_in_pixels / 2) - (g->height / 2);
+	int			x  = (cur_monitor->rectangle.width / 2) - (g->width / 2);
+	int			y  = (cur_monitor->rectangle.height / 2) - (g->height / 2);
 	rectangle_t rc = {
 		.x = x, .y = y, .width = g->width, .height = g->height};
 	new_node->rectangle = new_node->floating_rectangle = rc;

--- a/src/zwm.c
+++ b/src/zwm.c
@@ -166,6 +166,7 @@ load_cursors(void)
 	if (xcb_cursor_context_new(wm->connection, wm->screen, &cursor_ctx) <
 		0) {
 		_LOG_(ERROR, "failed to allocate xcursor context");
+		return;
 	}
 #define _LOAD_CURSOR_(cursor, name)                                       \
 	do {                                                                  \
@@ -175,8 +176,8 @@ load_cursors(void)
 	_LOAD_CURSOR_(CURSOR_WATCH, "watch");
 	_LOAD_CURSOR_(CURSOR_MOVE, "fleur");
 	_LOAD_CURSOR_(CURSOR_XTERM, "xterm");
-	_LOAD_CURSOR_(CURSOR_NOT_ALLOWED, "hand2");
-	_LOAD_CURSOR_(CURSOR_HAND2, "not-allowed");
+	_LOAD_CURSOR_(CURSOR_NOT_ALLOWED, "not-allowed");
+	_LOAD_CURSOR_(CURSOR_HAND2, "hand2");
 #undef _LOAD_CURSOR_
 }
 
@@ -201,7 +202,6 @@ set_cursor(int cursor_id)
 			  "Error setting cursor on root window %d\n",
 			  err->error_code);
 		free(err);
-		exit(EXIT_FAILURE);
 	}
 }
 
@@ -3710,6 +3710,7 @@ handle_enter_notify(const xcb_enter_notify_event_t *ev)
 				return -1;
 			}
 		}
+		// set_cursor(CURSOR_NOT_ALLOWED);
 		return 0;
 	}
 
@@ -4285,7 +4286,7 @@ handle_button_press_event(xcb_button_press_event_t *ev)
 
 	update_focus(root, n);
 	xcb_allow_events(wm->connection, XCB_ALLOW_SYNC_POINTER, ev->time);
-
+	// set_cursor(CURSOR_POINTER);
 	xcb_flush(wm->connection);
 }
 

--- a/src/zwm.h
+++ b/src/zwm.h
@@ -57,6 +57,7 @@ void                      free_clients();
 void 					  raise_window(xcb_window_t win);
 void 		              lower_window(xcb_window_t win);
 void                      grab_buttons(xcb_window_t win);
+void                      window_grab_buttons(xcb_window_t win);
 void 					  window_above(xcb_window_t, xcb_window_t);
 void 				      window_below(xcb_window_t, xcb_window_t);
 void				      update_grabbed_window(node_t *root, node_t *n);

--- a/src/zwm.h
+++ b/src/zwm.h
@@ -37,11 +37,16 @@
 extern config_t 		  conf;
 extern wm_t 			  *wm;
 extern xcb_window_t 	  focused_win;
+extern monitor_t		  *prim_monitor;
+extern monitor_t 		  *cur_monitor;
+extern 					  bool using_xrandr;
+extern 				      bool using_xinerama;
+extern 					  uint8_t randr_base;
+
 xcb_get_geometry_reply_t *get_geometry(xcb_window_t win, xcb_conn_t *c);
 xcb_atom_t                get_atom(char *atom_name, xcb_conn_t *con);
 client_t                 *create_client(xcb_window_t win, xcb_atom_t wtype, xcb_conn_t *cn);
 client_t                 *find_client_by_window(xcb_window_t win);
-wm_t                     *init_wm();
 xcb_window_t 			  get_window_under_cursor(xcb_conn_t *conn, xcb_window_t win);
 bool                      window_exists(xcb_conn_t *conn, xcb_window_t win);
 bool					  should_ignore_hints(xcb_window_t win, const char *name);
@@ -56,6 +61,8 @@ void 					  window_above(xcb_window_t, xcb_window_t);
 void 				      window_below(xcb_window_t, xcb_window_t);
 void				      update_grabbed_window(node_t *root, node_t *n);
 void 					  ungrab_keys(xcb_conn_t *conn, xcb_window_t win);
+desktop_t                *get_focused_desktop(void);
+monitor_t                *get_focused_monitor();
 int16_t                   get_cursor_axis(xcb_conn_t *conn, xcb_window_t window);
 int                       exec_process(arg_t *arg);
 int 					  layout_handler(arg_t *arg);
@@ -97,9 +104,7 @@ int                       configure_window(xcb_conn_t *, xcb_window_t, uint16_t,
 int                       set_input_focus(xcb_conn_t *, uint8_t, xcb_window_t, xcb_timestamp_t );
 int                       handle_xcb_error(xcb_conn_t *, xcb_void_cookie_t, const char *);
 int 					  swap_node_wrapper();
-int
-ewmh_update_current_desktop(xcb_ewmh_connection_t *ewmh,
-							int					   screen_nbr,
-							uint32_t			   i);
+int                       ewmh_update_current_desktop(xcb_ewmh_connection_t*, int, uint32_t);
 char 					  *win_name(xcb_window_t win);
+int                       ewmh_update_number_of_desktops(void);
 #endif // ZWM_ZWM_H


### PR DESCRIPTION
This PR adds multi-monitor support to ZWM and fixes the following bugs:
1- double free in split_string() which causes zwm to exit with SIGABRT as it starts up.
2- attempt to deference a null pointer when trying to delete a node in master layout, this leads to immediate crash.   
