### PR TITLE
Xrandr fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ LDFLAGS = -lxcb -lxcb-util -lxcb-keysyms -lxcb-ewmh -lxcb-icccm -lxcb-randr -lxc
 SRC_FILES = ./src/zwm.c ./src/logger.c ./src/tree.c ./src/config_parser.c ./src/queue.c
 HEADER_FILES = ./src/logger.h ./src/tree.h ./src/type.h ./src/zwm.h ./src/config_parser.h ./src/helper.h ./src/queue.h
 OBJ_FILES = $(SRC_FILES:.c=.o)
-DEBUG_FLAGS = -g -O0 -D_DEBUG__=1
+DEBUG_FLAGS = -g -D_DEBUG__=1
 GDB_FLAGS = -ggdb3
 LOCAL_TEST = -D__LTEST__=1
 TARGET = zwm

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 CC = gcc
-CFLAGS = -Wextra -Wshadow -Wunreachable-code -Wcast-align -Wuninitialized -finline-functions -finline-small-functions -findirect-inlining -fstrict-aliasing -falign-functions -falign-jumps -falign-labels -falign-loops -fprefetch-loop-arrays -fdump-rtl-loop2
+CFLAGS = -Wextra -Wshadow -Wunreachable-code -Wcast-align -Wuninitialized -finline-functions -finline-small-functions
 
 LDFLAGS = -lxcb -lxcb-util -lxcb-keysyms -lxcb-ewmh -lxcb-icccm -lxcb-randr -lxcb-xinerama -lxcb-cursor
-SRC_FILES = ./src/zwm.c ./src/logger.c ./src/tree.c ./src/config_parser.c
-HEADER_FILES = ./src/logger.h ./src/tree.h ./src/type.h ./src/zwm.h ./src/config_parser.h ./src/helper.h
+SRC_FILES = ./src/zwm.c ./src/logger.c ./src/tree.c ./src/config_parser.c ./src/queue.c
+HEADER_FILES = ./src/logger.h ./src/tree.h ./src/type.h ./src/zwm.h ./src/config_parser.h ./src/helper.h ./src/queue.h
 OBJ_FILES = $(SRC_FILES:.c=.o)
 DEBUG_FLAGS = -g -O0 -D_DEBUG__=1
 GDB_FLAGS = -ggdb3

--- a/_clang-format
+++ b/_clang-format
@@ -1,7 +1,7 @@
 TabWidth: 4
 IndentWidth: 4
 UseTab: Always
-ColumnLimit: 75
+ColumnLimit: 80
 AccessModifierOffset: 1
 AlignAfterOpenBracket: Align
 AlignArrayOfStructures: Left

--- a/src/config_parser.c
+++ b/src/config_parser.c
@@ -62,10 +62,6 @@ typedef enum {
 	QUOTATION
 } trim_token_t;
 
-// _key__t **conf_keys = NULL;
-// int		  _entries_ = 0;
-// rule_t	**_rules	 = NULL;
-// int		  rule_index = 0;
 rule_t	   *rule_head = NULL;
 conf_key_t *key_head  = NULL;
 
@@ -73,55 +69,50 @@ static void
 free_tokens(char **, int);
 
 // clang-format off
-static conf_mapper_t _cmapper_[] = {
- 	{"run", 					 exec_process},
- 	{"kill", 		    close_or_kill_wrapper},
- 	{"switch_desktop", switch_desktop_wrapper},
- 	{"resize", 		horizontal_resize_wrapper},
- 	{"fullscreen", 	   set_fullscreen_wrapper},
- 	{"swap", 				swap_node_wrapper},
- 	{"transfer_node", 	transfer_node_wrapper},
- 	{"layout", 				   layout_handler},
- 	{"traverse",       traverse_stack_wrapper},
-	{"flip", 	            flip_node_wrapper},
-	{"cycle_window", 	    cycle_win_wrapper},
-	{"reload_config",   reload_config_wrapper},
-	{"cycle_desktop",   cycle_desktop_wrapper},
-	{"shift_window", 	shift_floating_window},
-	{"gap_handler", 			  gap_handler},
-	{"change_state",             change_state}
+static const conf_mapper_t _cmapper_[] = {
+    DEFINE_MAPPING("run",            exec_process),
+    DEFINE_MAPPING("kill",           close_or_kill_wrapper),
+    DEFINE_MAPPING("switch_desktop", switch_desktop_wrapper),
+    DEFINE_MAPPING("resize",         horizontal_resize_wrapper),
+    DEFINE_MAPPING("fullscreen",     set_fullscreen_wrapper),
+    DEFINE_MAPPING("swap",           swap_node_wrapper),
+    DEFINE_MAPPING("transfer_node",  transfer_node_wrapper),
+    DEFINE_MAPPING("layout",         layout_handler),
+    DEFINE_MAPPING("traverse",       traverse_stack_wrapper),
+    DEFINE_MAPPING("flip",           flip_node_wrapper),
+    DEFINE_MAPPING("cycle_window",   cycle_win_wrapper),
+    DEFINE_MAPPING("reload_config",  reload_config_wrapper),
+    DEFINE_MAPPING("cycle_desktop",  cycle_desktop_wrapper),
+    DEFINE_MAPPING("shift_window",   shift_floating_window),
+    DEFINE_MAPPING("gap_handler",    gap_handler),
+    DEFINE_MAPPING("change_state",   change_state),
 };
 
-static key_mapper_t	 _kmapper_[] = {
- 	{"0", 0x0030}, {"1", 0x0031},
-	{"2", 0x0032}, {"3", 0x0033},
-	{"4", 0x0034}, {"5", 0x0035},
- 	{"6", 0x0036}, {"7", 0x0037},
-	{"8", 0x0038}, {"9", 0x0039},
-	{"a", 0x0061}, {"b", 0x0062},
-	{"c", 0x0063}, {"d", 0x0064},
-	{"e", 0x0065}, {"f", 0x0066},
-	{"g", 0x0067}, {"h", 0x0068},
- 	{"i", 0x0069}, {"j", 0x006a},
-	{"k", 0x006b}, {"l", 0x006c},
-	{"m", 0x006d}, {"n", 0x006e},
-	{"o", 0x006f}, {"p", 0x0070},
-	{"q", 0x0071}, {"r", 0x0072},
-	{"s", 0x0073}, {"t", 0x0074},
-	{"u", 0x0075}, {"v", 0x0076},
-	{"w", 0x0077}, {"x", 0x0078},
-	{"y", 0x0079}, {"z", 0x007a},
-	{"space", 	   	     0x0020},
-	{"return", 	         0xff0d},
-	{"left", 	   	     0xff51},
-	{"up", 	   	         0xff52},
-	{"right", 	         0xff53},
-	{"down", 	         0xff54},
- 	{"super",             SUPER},
- 	{"alt",                 ALT},
- 	{"ctrl",    		   CTRL},
- 	{"shift", 		      SHIFT},
-    {"sup+sh",      SUPER|SHIFT},
+static key_mapper_t _kmapper_[] = {
+    DEFINE_MAPPING("0",        0x0030), DEFINE_MAPPING("1",        0x0031),
+    DEFINE_MAPPING("2",        0x0032), DEFINE_MAPPING("3",        0x0033),
+    DEFINE_MAPPING("4",        0x0034), DEFINE_MAPPING("5",        0x0035),
+    DEFINE_MAPPING("6",        0x0036), DEFINE_MAPPING("7",        0x0037),
+    DEFINE_MAPPING("8",        0x0038), DEFINE_MAPPING("9",        0x0039),
+    DEFINE_MAPPING("a",        0x0061), DEFINE_MAPPING("b",        0x0062),
+    DEFINE_MAPPING("c",        0x0063), DEFINE_MAPPING("d",        0x0064),
+    DEFINE_MAPPING("e",        0x0065), DEFINE_MAPPING("f",        0x0066),
+    DEFINE_MAPPING("g",        0x0067), DEFINE_MAPPING("h",        0x0068),
+    DEFINE_MAPPING("i",        0x0069), DEFINE_MAPPING("j",        0x006a),
+    DEFINE_MAPPING("k",        0x006b), DEFINE_MAPPING("l",        0x006c),
+    DEFINE_MAPPING("m",        0x006d), DEFINE_MAPPING("n",        0x006e),
+    DEFINE_MAPPING("o",        0x006f), DEFINE_MAPPING("p",        0x0070),
+    DEFINE_MAPPING("q",        0x0071), DEFINE_MAPPING("r",        0x0072),
+    DEFINE_MAPPING("s",        0x0073), DEFINE_MAPPING("t",        0x0074),
+    DEFINE_MAPPING("u",        0x0075), DEFINE_MAPPING("v",        0x0076),
+    DEFINE_MAPPING("w",        0x0077), DEFINE_MAPPING("x",        0x0078),
+    DEFINE_MAPPING("y",        0x0079), DEFINE_MAPPING("z",        0x007a),
+    DEFINE_MAPPING("space",    0x0020), DEFINE_MAPPING("return",   0xff0d),
+    DEFINE_MAPPING("left",     0xff51), DEFINE_MAPPING("up",       0xff52),
+    DEFINE_MAPPING("right",    0xff53), DEFINE_MAPPING("down",     0xff54),
+    DEFINE_MAPPING("super",     SUPER), DEFINE_MAPPING("alt",        ALT ),
+    DEFINE_MAPPING("ctrl",      CTRL ), DEFINE_MAPPING("shift",     SHIFT),
+    DEFINE_MAPPING("sup+sh", SUPER | SHIFT),
 };
 // clang-format on
 
@@ -483,7 +474,7 @@ trim(char *str, trim_token_t t)
 	}
 }
 
-// caller must free using free_tokens(...)
+/* caller must free using free_tokens(...) */
 static char **
 split_string(const char *str, char delimiter, int *count)
 {
@@ -557,7 +548,7 @@ key_exist(conf_key_t *key)
 	return false;
 }
 
-// caller must free
+/* caller must free */
 static char *
 extract_body(const char *str)
 {
@@ -775,14 +766,14 @@ construct_key(char *mod, char *keysym, char *func, conf_key_t *key)
 	uint32_t _mod		= -1;
 	int (*ptr)(arg_t *) = NULL;
 
-	// parse mod key
+	/* parse mod key */
 	_mod				= parse_mod_key(mod);
 	if ((int)_mod == -1) {
 		_LOG_(ERROR, "failed to parse mod key for %s, func %s\n", mod, func);
 		return -1;
 	}
 
-	// parse keysym if not null
+	/* parse keysym if not null */
 	if (keysym) {
 		_keysym = parse_keysym(keysym);
 		if ((int)_keysym == -1) {
@@ -843,7 +834,7 @@ construct_key(char *mod, char *keysym, char *func, conf_key_t *key)
 		return 0;
 	}
 
-	// handle "run" functions
+	/* handle "run" functions */
 	if (run_func) {
 		ptr = str_to_func("run");
 		if (ptr == NULL) {
@@ -857,7 +848,7 @@ construct_key(char *mod, char *keysym, char *func, conf_key_t *key)
 		return 0;
 	}
 
-	// handle other functions
+	/* handle other functions */
 	ptr = str_to_func(func_param);
 	if (ptr == NULL) {
 		_LOG_(ERROR, "failed to find function pointer for %s", func_param);
@@ -880,7 +871,6 @@ parse_keybinding(char *str, conf_key_t *key)
 		return -1;
 	}
 
-	// bool  keysym_exists = strchr(str, '+') ;
 	char plus		   = '+';
 	bool keysym_exists = false;
 	int	 i			   = 0;
@@ -1033,7 +1023,7 @@ construct_rule(char *class, char *state, char *desktop_number, rule_t *rule)
 		return -1;
 	}
 
-	// wm_class
+	/* wm_class */
 	char *c = extract_body(class);
 	if (c == NULL) {
 		_LOG_(ERROR, "while extracting class rule body (%s)", class);
@@ -1045,7 +1035,7 @@ construct_rule(char *class, char *state, char *desktop_number, rule_t *rule)
 	uint32_t c_len = strlen(c);
 	strncpy(rule->win_name, c, c_len);
 
-	// w_state
+	/* w_state */
 	char *s = extract_body(state);
 	if (s == NULL) {
 		_LOG_(ERROR, "while extracting state rule body");
@@ -1060,7 +1050,7 @@ construct_rule(char *class, char *state, char *desktop_number, rule_t *rule)
 	}
 	rule->state = enum_state;
 
-	// w_desktop
+	/* w_desktop */
 	char *d		= extract_body(desktop_number);
 	if (d == NULL) {
 		_LOG_(ERROR, "while extracting desktop rule body");
@@ -1250,17 +1240,21 @@ free_keys(void)
 	conf_key_t *current = key_head;
 	while (current) {
 		conf_key_t *next = current->next;
-		if (current->arg) {
-			if (current->arg->cmd) {
-				for (int j = 0; j < current->arg->argc; j++) {
-					if (current->arg->cmd && current->arg->cmd[j]) {
-						_FREE_(current->arg->cmd[j]);
-					}
-				}
-				_FREE_(current->arg->cmd);
-			}
-			_FREE_(current->arg);
+		if (!current->arg) {
+			current = next;
+			continue;
 		}
+		if (!current->arg->cmd) {
+			current = next;
+			continue;
+		}
+		for (int j = 0; j < current->arg->argc; j++) {
+			if (current->arg->cmd && current->arg->cmd[j]) {
+				_FREE_(current->arg->cmd[j]);
+			}
+		}
+		_FREE_(current->arg->cmd);
+		_FREE_(current->arg);
 		_FREE_(current);
 		current = next;
 	}

--- a/src/config_parser.c
+++ b/src/config_parser.c
@@ -68,7 +68,7 @@ conf_key_t *key_head  = NULL;
 static void
 free_tokens(char **, int);
 
-// clang-format off
+/* clang-format off */
 static const conf_mapper_t _cmapper_[] = {
     DEFINE_MAPPING("run",            exec_process),
     DEFINE_MAPPING("kill",           close_or_kill_wrapper),
@@ -114,7 +114,7 @@ static key_mapper_t _kmapper_[] = {
     DEFINE_MAPPING("ctrl",      CTRL ), DEFINE_MAPPING("shift",     SHIFT),
     DEFINE_MAPPING("sup+sh", SUPER | SHIFT),
 };
-// clang-format on
+/* clang-format on */
 
 static int (*str_to_func(char *ch))(arg_t *)
 {
@@ -209,8 +209,8 @@ print_key_array(void)
 static int
 write_default_config(const char *filename, config_t *c)
 {
-	// clang-format off
-const char *content =
+	/* clang-format off */
+	const char *content =
     "; ----------- ZWM Configuration File -------------\n"
     ";\n"
     "; This configuration file is used to customize the Zee Window Manager (ZWM) settings.\n"
@@ -378,8 +378,8 @@ const char *content =
     "; reload the configuration file\n"
     "bind = super|shift + r -> func(reload_config)\n"
     "\n";
+	/* clang-format on */
 
-	// clang-format on
 	char dir_path[strlen(filename) + 1];
 	strcpy(dir_path, filename);
 	char *last_slash = strrchr(dir_path, '/');
@@ -388,7 +388,7 @@ const char *content =
 		struct stat st;
 		if (stat(dir_path, &st) == -1) {
 			if (mkdir(dir_path, 0777) == -1) {
-				_LOG_(ERROR, "failed to create directory: %s\n", dir_path);
+				_LOG_(ERROR, "failed to create directory: %s", dir_path);
 				return -1;
 			}
 		}
@@ -396,7 +396,7 @@ const char *content =
 
 	FILE *file = fopen(filename, "w");
 	if (file == NULL) {
-		_LOG_(ERROR, "failed to create config file: %s\n", filename);
+		_LOG_(ERROR, "failed to create config file: %s", filename);
 		return -1;
 	}
 
@@ -404,7 +404,7 @@ const char *content =
 	size_t written = fwrite(content, 1, len, file);
 	if (written != len) {
 		fclose(file);
-		_LOG_(ERROR, "error writing to file: %s\n", filename);
+		_LOG_(ERROR, "error writing to file: %s", filename);
 		return -1;
 	}
 
@@ -585,16 +585,16 @@ parse_mod_key(char *mod)
 		int	   count;
 		char **mods = split_string(mod, '|', &count);
 		if (mods == NULL) {
-			_LOG_(ERROR, "failed to split string %s\n", mod);
+			_LOG_(ERROR, "failed to split string %s", mod);
 			return -1;
 		}
 		uint32_t mask1 = str_to_key(mods[0]);
 		if ((int)mask1 == -1) {
-			_LOG_(ERROR, "failed to find key (%s)\n", mods[0]);
+			_LOG_(ERROR, "failed to find key (%s)", mods[0]);
 		}
 		uint32_t mask2 = str_to_key(mods[1]);
 		if ((int)mask2 == -1) {
-			_LOG_(ERROR, "failed to find key (%s)\n", mods[1]);
+			_LOG_(ERROR, "failed to find key (%s)", mods[1]);
 		}
 		mask = mask1 | mask2;
 		free_tokens(mods, count);
@@ -609,7 +609,7 @@ parse_keysym(char *keysym)
 {
 	uint32_t keysym_ = str_to_key(keysym);
 	if ((int)keysym_ == -1) {
-		_LOG_(ERROR, "failed to find keysym %s\n", keysym);
+		_LOG_(ERROR, "failed to find keysym %s", keysym);
 		return -1;
 	}
 
@@ -769,7 +769,7 @@ construct_key(char *mod, char *keysym, char *func, conf_key_t *key)
 	/* parse mod key */
 	_mod				= parse_mod_key(mod);
 	if ((int)_mod == -1) {
-		_LOG_(ERROR, "failed to parse mod key for %s, func %s\n", mod, func);
+		_LOG_(ERROR, "failed to parse mod key for %s, func %s", mod, func);
 		return -1;
 	}
 
@@ -777,24 +777,24 @@ construct_key(char *mod, char *keysym, char *func, conf_key_t *key)
 	if (keysym) {
 		_keysym = parse_keysym(keysym);
 		if ((int)_keysym == -1) {
-			_LOG_(ERROR, "failed to parse keysym for %s\n", keysym);
+			_LOG_(ERROR, "failed to parse keysym for %s", keysym);
 			return -1;
 		}
 	} else {
 		_LOG_(
-			INFO, "keysym is null, func must be switch or transfer %s\n", func);
+			INFO, "keysym is null, func must be switch or transfer %s", func);
 	}
 
 	if (strncmp(func, "run", 3) == 0) {
 		run_func = true;
 #ifdef _DEBUG__
-		_LOG_(INFO, "found run func %s, ...\n", func);
+		_LOG_(INFO, "found run func %s, ...", func);
 #endif
 	}
 
 	char *func_param = extract_body(func);
 	if (func_param == NULL) {
-		_LOG_(ERROR, "failed to extract func body for %s\n", func);
+		_LOG_(ERROR, "failed to extract func body for %s", func);
 		return -1;
 	}
 
@@ -805,7 +805,7 @@ construct_key(char *mod, char *keysym, char *func, conf_key_t *key)
 		char **s	 = split_string(func_param, ':', &count);
 		if (s == NULL || count != 2) {
 			_LOG_(ERROR,
-				  "failed to split string or incorrect count for %s\n",
+				  "failed to split string or incorrect count for %s",
 				  func_param);
 			_FREE_(func_param);
 			if (s)
@@ -1145,35 +1145,35 @@ parse_config_line(char *key, char *value, config_t *c, bool reload)
 		} else if (strcmp(value, "false") == 0) {
 			c->focus_follow_pointer = false;
 		} else {
-			_LOG_(ERROR, "invalid value for focus_follow_pointer: %s\n", value);
+			_LOG_(ERROR, "invalid value for focus_follow_pointer: %s", value);
 			return -1;
 		}
 	} else if (strcmp(key, "rule") == 0) {
 		rule_t *rule = init_rule();
 		if (rule == NULL) {
-			_LOG_(ERROR, "failed to allocate memory for rule_t\n");
+			_LOG_(ERROR, "failed to allocate memory for rule_t");
 			return -1;
 		}
 		if (parse_rule(value, rule) != 0) {
 			_FREE_(rule);
-			_LOG_(ERROR, "error while parsing rule %s\n", value);
+			_LOG_(ERROR, "error while parsing rule %s", value);
 			return -1;
 		}
 		add_rule(&rule_head, rule);
 	} else if (strcmp(key, "bind") == 0) {
 		conf_key_t *k = init_key();
 		if (k == NULL) {
-			_LOG_(ERROR, "failed to allocate memory for _key__t\n");
+			_LOG_(ERROR, "failed to allocate memory for _key__t");
 			return -1;
 		}
 		if (parse_keybinding(value, k) != 0) {
 			err_cleanup(k);
-			_LOG_(ERROR, "error while parsing keys\n");
+			_LOG_(ERROR, "error while parsing keys");
 			return -1;
 		}
 		add_key(&key_head, k);
 	} else {
-		_LOG_(WARNING, "unknown config key: %s\n", key);
+		_LOG_(WARNING, "unknown config key: %s", key);
 	}
 	return 0;
 }
@@ -1183,7 +1183,7 @@ parse_config(const char *filename, config_t *c, bool reload)
 {
 	FILE *file = fopen(filename, "r");
 	if (file == NULL) {
-		_LOG_(ERROR, "error: could not open file '%s'\n", filename);
+		_LOG_(ERROR, "error: could not open file '%s'", filename);
 		return -1;
 	}
 
@@ -1206,7 +1206,7 @@ parse_config(const char *filename, config_t *c, bool reload)
 
 #ifdef _DEBUG__
 		_LOG_(DEBUG,
-			  "config line = (%s) key = (%s) value = (%s)\n",
+			  "config line = (%s) key = (%s) value = (%s)",
 			  line,
 			  key,
 			  value);

--- a/src/config_parser.c
+++ b/src/config_parser.c
@@ -1226,7 +1226,7 @@ free_rules(void)
 	rule_t *current = rule_head;
 	while (current) {
 		rule_t *next = current->next;
-		free(current);
+		_FREE_(current);
 		current = next;
 	}
 	rule_head = NULL;

--- a/src/config_parser.c
+++ b/src/config_parser.c
@@ -178,7 +178,7 @@ static int
 file_exists(const char *filename)
 {
 	FILE *file = fopen(filename, "r");
-	if (file != NULL) {
+	if (file) {
 		fclose(file);
 		return -1;
 	}
@@ -190,9 +190,9 @@ print_key_array(void)
 {
 	conf_key_t *current = key_head;
 	int			c		= 0;
-	while (current != NULL) {
-		if (current->arg != NULL) {
-			if (current->arg->cmd != NULL) {
+	while (current) {
+		if (current->arg) {
+			if (current->arg->cmd) {
 				for (int j = 0; j < current->arg->argc; ++j) {
 					_LOG_(DEBUG, "cmd = %s", current->arg->cmd[j]);
 				}
@@ -392,12 +392,12 @@ const char *content =
 	char dir_path[strlen(filename) + 1];
 	strcpy(dir_path, filename);
 	char *last_slash = strrchr(dir_path, '/');
-	if (last_slash != NULL) {
+	if (last_slash) {
 		*last_slash = '\0';
 		struct stat st;
 		if (stat(dir_path, &st) == -1) {
 			if (mkdir(dir_path, 0777) == -1) {
-				_LOG_(ERROR, "Failed to create directory: %s\n", dir_path);
+				_LOG_(ERROR, "failed to create directory: %s\n", dir_path);
 				return -1;
 			}
 		}
@@ -405,7 +405,7 @@ const char *content =
 
 	FILE *file = fopen(filename, "w");
 	if (file == NULL) {
-		_LOG_(ERROR, "Failed to create config file: %s\n", filename);
+		_LOG_(ERROR, "failed to create config file: %s\n", filename);
 		return -1;
 	}
 
@@ -413,7 +413,7 @@ const char *content =
 	size_t written = fwrite(content, 1, len, file);
 	if (written != len) {
 		fclose(file);
-		_LOG_(ERROR, "Error writing to file: %s\n", filename);
+		_LOG_(ERROR, "error writing to file: %s\n", filename);
 		return -1;
 	}
 
@@ -474,8 +474,7 @@ trim(char *str, trim_token_t t)
 		end--;
 	}
 
-	while (*start == start_token ||
-		   (t == WHITE_SPACE && isspace(*start))) {
+	while (*start == start_token || (t == WHITE_SPACE && isspace(*start))) {
 		start++;
 	}
 
@@ -512,7 +511,7 @@ split_string(const char *str, char delimiter, int *count)
 	char  delim_str[2] = {delimiter, '\0'};
 	char *token		   = strtok(str_copy, delim_str);
 	i				   = 0;
-	while (token != NULL && i < num_tokens) {
+	while (token && i < num_tokens) {
 		tokens[i] = strdup(token);
 		if (tokens[i] == NULL) {
 			_LOG_(ERROR, "failed to duplicate token");
@@ -533,9 +532,9 @@ split_string(const char *str, char delimiter, int *count)
 static void
 free_tokens(char **tokens, int count)
 {
-	if (tokens != NULL) {
+	if (tokens) {
 		for (int i = 0; i < count; i++) {
-			if (tokens[i] != NULL) {
+			if (tokens[i]) {
 				_FREE_(tokens[i]);
 			}
 		}
@@ -547,7 +546,7 @@ static bool
 key_exist(conf_key_t *key)
 {
 	conf_key_t *current = key_head;
-	while (current != NULL) {
+	while (current) {
 		if (current->function_ptr == key->function_ptr &&
 			current->keysym == key->keysym) {
 			return true;
@@ -629,9 +628,9 @@ parse_keysym(char *keysym)
 static void
 err_cleanup(conf_key_t *k)
 {
-	if (k != NULL) {
-		if (k->arg != NULL) {
-			if (k->arg->cmd != NULL) {
+	if (k) {
+		if (k->arg) {
+			if (k->arg->cmd) {
 				for (int i = 0; i < k->arg->argc; i++) {
 					_FREE_(k->arg->cmd[i]);
 				}
@@ -644,10 +643,7 @@ err_cleanup(conf_key_t *k)
 }
 
 static void
-build_run_func(char		  *func_param,
-			   conf_key_t *key,
-			   uint32_t	   mod,
-			   uint32_t	   keysym)
+build_run_func(char *func_param, conf_key_t *key, uint32_t mod, uint32_t keysym)
 {
 	key->mod	= mod;
 	key->keysym = (xcb_keysym_t)keysym;
@@ -782,22 +778,20 @@ construct_key(char *mod, char *keysym, char *func, conf_key_t *key)
 	// parse mod key
 	_mod				= parse_mod_key(mod);
 	if ((int)_mod == -1) {
-		_LOG_(
-			ERROR, "failed to parse mod key for %s, func %s\n", mod, func);
+		_LOG_(ERROR, "failed to parse mod key for %s, func %s\n", mod, func);
 		return -1;
 	}
 
 	// parse keysym if not null
-	if (keysym != NULL) {
+	if (keysym) {
 		_keysym = parse_keysym(keysym);
 		if ((int)_keysym == -1) {
 			_LOG_(ERROR, "failed to parse keysym for %s\n", keysym);
 			return -1;
 		}
 	} else {
-		_LOG_(INFO,
-			  "keysym is null, func must be switch or transfer %s\n",
-			  func);
+		_LOG_(
+			INFO, "keysym is null, func must be switch or transfer %s\n", func);
 	}
 
 	if (strncmp(func, "run", 3) == 0) {
@@ -823,7 +817,7 @@ construct_key(char *mod, char *keysym, char *func, conf_key_t *key)
 				  "failed to split string or incorrect count for %s\n",
 				  func_param);
 			_FREE_(func_param);
-			if (s != NULL)
+			if (s)
 				_FREE_(s);
 			return -1;
 		}
@@ -853,9 +847,7 @@ construct_key(char *mod, char *keysym, char *func, conf_key_t *key)
 	if (run_func) {
 		ptr = str_to_func("run");
 		if (ptr == NULL) {
-			_LOG_(ERROR,
-				  "failed to find run func pointer for %s",
-				  func_param);
+			_LOG_(ERROR, "failed to find run func pointer for %s", func_param);
 			_FREE_(func_param);
 			return -1;
 		}
@@ -888,7 +880,7 @@ parse_keybinding(char *str, conf_key_t *key)
 		return -1;
 	}
 
-	// bool  keysym_exists = strchr(str, '+') != NULL;
+	// bool  keysym_exists = strchr(str, '+') ;
 	char plus		   = '+';
 	bool keysym_exists = false;
 	int	 i			   = 0;
@@ -958,7 +950,7 @@ add_key(conf_key_t **head, conf_key_t *k)
 		return;
 	}
 	conf_key_t *current = *head;
-	while (current->next != NULL) {
+	while (current->next) {
 		current = current->next;
 	}
 	current->next = k;
@@ -985,7 +977,7 @@ add_rule(rule_t **head, rule_t *r)
 		return;
 	}
 	rule_t *current = *head;
-	while (current->next != NULL) {
+	while (current->next) {
 		current = current->next;
 	}
 	current->next = r;
@@ -1034,10 +1026,7 @@ handle_exec_cmd(char *cmd)
 }
 
 static int
-construct_rule(char *class,
-			   char	  *state,
-			   char	  *desktop_number,
-			   rule_t *rule)
+construct_rule(char *class, char *state, char *desktop_number, rule_t *rule)
 {
 	if (class == NULL || state == NULL || desktop_number == NULL) {
 		_LOG_(ERROR, "rules are empty");
@@ -1081,12 +1070,11 @@ construct_rule(char *class,
 	trim(d, PARENTHESIS);
 	rule->desktop_id = atoi(d);
 
-	_LOG_(
-		INFO,
-		"constructed rule = win name = (%s), state = (%s), desktop = (%d)",
-		rule->win_name,
-		rule->state == TILED ? "TILED" : "FLOATED",
-		rule->desktop_id);
+	_LOG_(INFO,
+		  "constructed rule = win name = (%s), state = (%s), desktop = (%d)",
+		  rule->win_name,
+		  rule->state == TILED ? "TILED" : "FLOATED",
+		  rule->desktop_id);
 	_FREE_(c);
 	_FREE_(s);
 	_FREE_(d);
@@ -1098,13 +1086,12 @@ rule_t *
 get_window_rule(xcb_window_t win)
 {
 	xcb_icccm_get_wm_class_reply_t t_reply;
-	xcb_get_property_cookie_t	   cn =
-		xcb_icccm_get_wm_class(wm->connection, win);
-	const uint8_t wr =
+	xcb_get_property_cookie_t cn = xcb_icccm_get_wm_class(wm->connection, win);
+	const uint8_t			  wr =
 		xcb_icccm_get_wm_class_reply(wm->connection, cn, &t_reply, NULL);
 	if (wr == 1) {
 		rule_t *current = rule_head;
-		while (current != NULL) {
+		while (current) {
 			if (strcasecmp(current->win_name, t_reply.class_name) == 0) {
 				xcb_icccm_get_wm_class_reply_wipe(&t_reply);
 				return current;
@@ -1139,7 +1126,7 @@ parse_rule(char *value, rule_t *rule)
 	char *win_state	  = rules[1];
 	char *win_desktop = rules[2];
 
-	int	  result = construct_rule(win_name, win_state, win_desktop, rule);
+	int	  result	  = construct_rule(win_name, win_state, win_desktop, rule);
 
 	free_tokens(rules, count);
 
@@ -1168,37 +1155,35 @@ parse_config_line(char *key, char *value, config_t *c, bool reload)
 		} else if (strcmp(value, "false") == 0) {
 			c->focus_follow_pointer = false;
 		} else {
-			_LOG_(ERROR,
-				  "Invalid value for focus_follow_pointer: %s\n",
-				  value);
+			_LOG_(ERROR, "invalid value for focus_follow_pointer: %s\n", value);
 			return -1;
 		}
 	} else if (strcmp(key, "rule") == 0) {
 		rule_t *rule = init_rule();
 		if (rule == NULL) {
-			_LOG_(ERROR, "Failed to allocate memory for rule_t\n");
+			_LOG_(ERROR, "failed to allocate memory for rule_t\n");
 			return -1;
 		}
 		if (parse_rule(value, rule) != 0) {
 			_FREE_(rule);
-			_LOG_(ERROR, "Error while parsing rule %s\n", value);
+			_LOG_(ERROR, "error while parsing rule %s\n", value);
 			return -1;
 		}
 		add_rule(&rule_head, rule);
 	} else if (strcmp(key, "bind") == 0) {
 		conf_key_t *k = init_key();
 		if (k == NULL) {
-			_LOG_(ERROR, "Failed to allocate memory for _key__t\n");
+			_LOG_(ERROR, "failed to allocate memory for _key__t\n");
 			return -1;
 		}
 		if (parse_keybinding(value, k) != 0) {
 			err_cleanup(k);
-			_LOG_(ERROR, "Error while parsing keys\n");
+			_LOG_(ERROR, "error while parsing keys\n");
 			return -1;
 		}
 		add_key(&key_head, k);
 	} else {
-		_LOG_(WARNING, "Unknown config key: %s\n", key);
+		_LOG_(WARNING, "unknown config key: %s\n", key);
 	}
 	return 0;
 }
@@ -1208,12 +1193,12 @@ parse_config(const char *filename, config_t *c, bool reload)
 {
 	FILE *file = fopen(filename, "r");
 	if (file == NULL) {
-		_LOG_(ERROR, "Error: Could not open file '%s'\n", filename);
+		_LOG_(ERROR, "error: could not open file '%s'\n", filename);
 		return -1;
 	}
 
 	char line[MAX_LINE_LENGTH];
-	while (fgets(line, MAX_LINE_LENGTH, file) != NULL) {
+	while (fgets(line, MAX_LINE_LENGTH, file)) {
 		if (line[0] == ' ' || line[0] == '\t' || line[0] == '\n' ||
 			line[0] == '\v' || line[0] == '\f' || line[0] == '\r' ||
 			line[0] == ';') {
@@ -1251,7 +1236,7 @@ void
 free_rules(void)
 {
 	rule_t *current = rule_head;
-	while (current != NULL) {
+	while (current) {
 		rule_t *next = current->next;
 		free(current);
 		current = next;
@@ -1263,13 +1248,12 @@ void
 free_keys(void)
 {
 	conf_key_t *current = key_head;
-	while (current != NULL) {
+	while (current) {
 		conf_key_t *next = current->next;
-		if (current->arg != NULL) {
-			if (current->arg->cmd != NULL) {
+		if (current->arg) {
+			if (current->arg->cmd) {
 				for (int j = 0; j < current->arg->argc; j++) {
-					if (current->arg->cmd != NULL &&
-						current->arg->cmd[j] != NULL) {
+					if (current->arg->cmd && current->arg->cmd[j]) {
 						_FREE_(current->arg->cmd[j]);
 					}
 				}
@@ -1278,6 +1262,7 @@ free_keys(void)
 			_FREE_(current->arg);
 		}
 		_FREE_(current);
+		current = next;
 	}
 	key_head = NULL;
 }

--- a/src/config_parser.c
+++ b/src/config_parser.c
@@ -27,7 +27,6 @@
  */
 #include "config_parser.h"
 #include "helper.h"
-#include "tree.h"
 #include "type.h"
 #include "zwm.h"
 #include <ctype.h>
@@ -121,7 +120,7 @@ static int (*str_to_func(char *ch))(arg_t *)
 	int n = sizeof(_cmapper_) / sizeof(_cmapper_[0]);
 	for (int i = 0; i < n; i++) {
 		if (strcmp(_cmapper_[i].func_name, ch) == 0) {
-			return _cmapper_[i].function_ptr;
+			return _cmapper_[i].execute;
 		}
 	}
 	return NULL;
@@ -132,7 +131,7 @@ func_to_str(int (*ptr)(arg_t *))
 {
 	int n = sizeof(_cmapper_) / sizeof(_cmapper_[0]);
 	for (int i = 0; i < n; i++) {
-		if (_cmapper_[i].function_ptr == ptr) {
+		if (_cmapper_[i].execute == ptr) {
 			return _cmapper_[i].func_name;
 		}
 	}
@@ -194,7 +193,7 @@ print_key_array(void)
 				  c,
 				  key_to_str(current->mod),
 				  key_to_str(current->keysym),
-				  func_to_str(current->function_ptr),
+				  func_to_str(current->execute),
 				  current->arg->idx,
 				  current->arg->d,
 				  current->arg->r,
@@ -538,7 +537,7 @@ key_exist(conf_key_t *key)
 {
 	conf_key_t *current = key_head;
 	while (current) {
-		if (current->function_ptr == key->function_ptr &&
+		if (current->execute == key->execute &&
 			current->keysym == key->keysym) {
 			return true;
 		}
@@ -781,8 +780,7 @@ construct_key(char *mod, char *keysym, char *func, conf_key_t *key)
 			return -1;
 		}
 	} else {
-		_LOG_(
-			INFO, "keysym is null, func must be switch or transfer %s", func);
+		_LOG_(INFO, "keysym is null, func must be switch or transfer %s", func);
 	}
 
 	if (strncmp(func, "run", 3) == 0) {
@@ -822,9 +820,9 @@ construct_key(char *mod, char *keysym, char *func, conf_key_t *key)
 			_FREE_(s);
 			return -1;
 		}
-		key->mod		  = _mod;
-		key->keysym		  = _keysym;
-		key->function_ptr = ptr;
+		key->mod	 = _mod;
+		key->keysym	 = _keysym;
+		key->execute = ptr;
 
 		set_key_args(key, f, a);
 		free_tokens(s, count);
@@ -843,7 +841,7 @@ construct_key(char *mod, char *keysym, char *func, conf_key_t *key)
 			return -1;
 		}
 		build_run_func(func_param, key, _mod, _keysym);
-		key->function_ptr = ptr;
+		key->execute = ptr;
 		_FREE_(func_param);
 		return 0;
 	}
@@ -856,9 +854,9 @@ construct_key(char *mod, char *keysym, char *func, conf_key_t *key)
 		return -1;
 	}
 
-	key->mod		  = _mod;
-	key->keysym		  = _keysym;
-	key->function_ptr = ptr;
+	key->mod	 = _mod;
+	key->keysym	 = _keysym;
+	key->execute = ptr;
 	_FREE_(func_param);
 	return 0;
 }

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -31,20 +31,17 @@
 
 #include "type.h"
 
-#define MAX_RULES (2 << 2) // 2 << 2 = 8
+#define MAX_RULES (2 << 2)
 
-// extern _key__t **conf_keys;
-// extern int		 _entries_;
-// extern rule_t  **_rules;
-// extern int		 rule_index;
 extern rule_t	  *rule_head;
 extern conf_key_t *key_head;
 
-// clang-format off
+/* clang-format off */
 rule_t *get_window_rule(xcb_window_t win);
-int     load_config(config_t *c);
-void    free_keys(void);
-void    free_rules(void);
-int     reload_config(config_t *c);
-// clang-format on
-#endif // ZWM_CONFIG_PARSER_H
+int load_config(config_t *c);
+void free_keys(void);
+void free_rules(void);
+int reload_config(config_t *c);
+/* clang-format on */
+
+#endif /* ZWM_CONFIG_PARSER_H */

--- a/src/helper.h
+++ b/src/helper.h
@@ -39,27 +39,35 @@
 #define IS_INTERNAL(n)	 (n->node_type == INTERNAL_NODE)
 #define IS_ROOT(n)		 (n->node_type == ROOT_NODE)
 
-#define _FREE_(ptr)                                                       \
-	do {                                                                  \
-		free(ptr);                                                        \
-		ptr = NULL;                                                       \
+#define DEFINE_KEY(mask, keysym, handler, arg)                                 \
+	{                                                                          \
+		mask, keysym, handler, arg                                             \
+	}
+#define DEFINE_MAPPING(name, value)                                            \
+	{                                                                          \
+		name, value                                                            \
+	}
+#define _FREE_(ptr)                                                            \
+	do {                                                                       \
+		free(ptr);                                                             \
+		ptr = NULL;                                                            \
 	} while (0)
 
-#define _LOG_(level, format, ...)                                         \
-	do {                                                                  \
-		log_message(level,                                                \
-					"[%s:%s():%d] " format,                               \
-					__FILE__,                                             \
-					__func__,                                             \
-					__LINE__,                                             \
-					##__VA_ARGS__);                                       \
+#define _LOG_(level, format, ...)                                              \
+	do {                                                                       \
+		log_message(level,                                                     \
+					"[%s:%s():%d] " format,                                    \
+					__FILE__,                                                  \
+					__func__,                                                  \
+					__LINE__,                                                  \
+					##__VA_ARGS__);                                            \
 	} while (0)
 
-#define MAX(a, b)                                                         \
-	({                                                                    \
-		__typeof__(a) _a = (a);                                           \
-		__typeof__(b) _b = (b);                                           \
-		_a > _b ? _a : _b;                                                \
+#define MAX(a, b)                                                              \
+	({                                                                         \
+		__typeof__(a) _a = (a);                                                \
+		__typeof__(b) _b = (b);                                                \
+		_a > _b ? _a : _b;                                                     \
 	})
 
 #endif // ZWM_HELPER_H

--- a/src/helper.h
+++ b/src/helper.h
@@ -41,10 +41,14 @@
 
 #define DEFINE_KEY(mask, keysym, handler, arg) {mask, keysym, handler, arg}
 #define DEFINE_MAPPING(name, value)			   {name, value}
+
+/* spent way too many hours hunting double-free bugs. This should handle it. */
 #define _FREE_(ptr)                                                            \
 	do {                                                                       \
-		free(ptr);                                                             \
-		ptr = NULL;                                                            \
+		if (ptr) {                                                             \
+			free(ptr);                                                         \
+			ptr = NULL;                                                        \
+		}                                                                      \
 	} while (0)
 
 #define _LOG_(level, format, ...)                                              \

--- a/src/helper.h
+++ b/src/helper.h
@@ -30,23 +30,17 @@
 
 #include "logger.h"
 
-#define LEN(x)			 (sizeof(x) / sizeof(*x))
-#define CLEANMASK(mask)	 (mask & ~(0 | XCB_MOD_MASK_LOCK))
-#define IS_TILED(c)		 (c->state == TILED)
-#define IS_FLOATING(c)	 (c->state == FLOATING)
-#define IS_FULLSCREEN(c) (c->state == FULLSCREEN)
-#define IS_EXTERNAL(n)	 (n->node_type == EXTERNAL_NODE)
-#define IS_INTERNAL(n)	 (n->node_type == INTERNAL_NODE)
-#define IS_ROOT(n)		 (n->node_type == ROOT_NODE)
+#define LEN(x)								   (sizeof(x) / sizeof(*x))
+#define CLEANMASK(mask)						   (mask & ~(0 | XCB_MOD_MASK_LOCK))
+#define IS_TILED(c)							   (c->state == TILED)
+#define IS_FLOATING(c)						   (c->state == FLOATING)
+#define IS_FULLSCREEN(c)					   (c->state == FULLSCREEN)
+#define IS_EXTERNAL(n)						   (n->node_type == EXTERNAL_NODE)
+#define IS_INTERNAL(n)						   (n->node_type == INTERNAL_NODE)
+#define IS_ROOT(n)							   (n->node_type == ROOT_NODE)
 
-#define DEFINE_KEY(mask, keysym, handler, arg)                                 \
-	{                                                                          \
-		mask, keysym, handler, arg                                             \
-	}
-#define DEFINE_MAPPING(name, value)                                            \
-	{                                                                          \
-		name, value                                                            \
-	}
+#define DEFINE_KEY(mask, keysym, handler, arg) {mask, keysym, handler, arg}
+#define DEFINE_MAPPING(name, value)			   {name, value}
 #define _FREE_(ptr)                                                            \
 	do {                                                                       \
 		free(ptr);                                                             \
@@ -70,4 +64,4 @@
 		_a > _b ? _a : _b;                                                     \
 	})
 
-#endif // ZWM_HELPER_H
+#endif /* ZWM_HELPER_H */

--- a/src/logger.h
+++ b/src/logger.h
@@ -30,8 +30,8 @@
 #define ZWM_LOGGER_H
 
 #include "type.h"
-// clang-format off
+/* clang-format off */
 void log_message(log_level_t level, const char *format, ...);
 void log_window_id(xcb_window_t window, const char *message);
-// clang-format on
-#endif // ZWM_LOGGER_H
+/* clang-format on */
+#endif /* ZWM_LOGGER_H */

--- a/src/queue.c
+++ b/src/queue.c
@@ -28,8 +28,6 @@
 
 #include "queue.h"
 #include "type.h"
-#include "helper.h"
-#include "zwm.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <xcb/xcb_icccm.h>

--- a/src/queue.c
+++ b/src/queue.c
@@ -1,0 +1,82 @@
+/*
+ * BSD 2-Clause License
+ * Copyright (c) 2024, Yazeed Alharthi
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *	  1. Redistributions of source code must retain the above copyright
+ *	  notice, this list of conditions and the following disclaimer.
+ *
+ *	  2. Redistributions in binary form must reproduce the above copyright
+ *	  notice, this list of conditions and the following disclaimer in the
+ *	  documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "queue.h"
+#include "type.h"
+#include <stdlib.h>
+
+queue_t *
+create_queue(void)
+{
+	queue_t *q = (queue_t *)malloc(sizeof(queue_t));
+	if (!q)
+		return NULL;
+	q->front = q->rear = NULL;
+	return q;
+}
+
+void
+enqueue(queue_t *q, node_t *n)
+{
+	queue_node_t *nnode = (queue_node_t *)malloc(sizeof(queue_node_t));
+	if (!nnode)
+		return;
+	nnode->tree_node = n;
+	nnode->next		 = NULL;
+	if (!q->rear) {
+		q->front = q->rear = nnode;
+		return;
+	}
+	q->rear->next = nnode;
+	q->rear		  = nnode;
+}
+
+node_t *
+dequeue(queue_t *q)
+{
+	if (!q->front)
+		return NULL;
+	queue_node_t *temp = q->front;
+	node_t		 *node = temp->tree_node;
+	q->front		   = q->front->next;
+	if (!q->front)
+		q->rear = NULL;
+	free(temp);
+	return node;
+}
+
+void
+free_queue(queue_t *q)
+{
+	while (q->front) {
+		queue_node_t *temp = q->front;
+		q->front		   = q->front->next;
+		free(temp);
+	}
+	free(q);
+}

--- a/src/queue.c
+++ b/src/queue.c
@@ -70,6 +70,12 @@ dequeue(queue_t *q)
 	return node;
 }
 
+bool
+is_queue_empty(queue_t *q)
+{
+	return q->front == NULL;
+}
+
 void
 free_queue(queue_t *q)
 {

--- a/src/queue.c
+++ b/src/queue.c
@@ -28,7 +28,11 @@
 
 #include "queue.h"
 #include "type.h"
+#include "helper.h"
+#include "zwm.h"
+#include <stdio.h>
 #include <stdlib.h>
+#include <xcb/xcb_icccm.h>
 
 queue_t *
 create_queue(void)

--- a/src/queue.h
+++ b/src/queue.h
@@ -1,0 +1,40 @@
+/*
+ * BSD 2-Clause License
+ * Copyright (c) 2024, Yazeed Alharthi
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *	  1. Redistributions of source code must retain the above copyright
+ *	  notice, this list of conditions and the following disclaimer.
+ *
+ *	  2. Redistributions in binary form must reproduce the above copyright
+ *	  notice, this list of conditions and the following disclaimer in the
+ *	  documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ZWM_QUEUE_H
+#define ZWM_QUEUE_H
+
+#include "type.h"
+
+// clang-format off
+queue_t *create_queue(void);
+void    enqueue(queue_t *queue, node_t *node);
+node_t  *dequeue(queue_t *queue);
+void    free_queue(queue_t *queue);
+// clang-format on
+#endif // ZWM_QUEUE_H

--- a/src/queue.h
+++ b/src/queue.h
@@ -33,9 +33,9 @@
 
 // clang-format off
 queue_t *create_queue(void);
-void    enqueue(queue_t *queue, node_t *node);
-node_t  *dequeue(queue_t *queue);
+void    enqueue(queue_t *q, node_t *n);
+node_t  *dequeue(queue_t *q);
 bool    is_queue_empty(queue_t *q);
-void    free_queue(queue_t *queue);
+void    free_queue(queue_t *q);
 // clang-format on
 #endif // ZWM_QUEUE_H

--- a/src/queue.h
+++ b/src/queue.h
@@ -35,6 +35,7 @@
 queue_t *create_queue(void);
 void    enqueue(queue_t *queue, node_t *node);
 node_t  *dequeue(queue_t *queue);
+bool    is_queue_empty(queue_t *q);
 void    free_queue(queue_t *queue);
 // clang-format on
 #endif // ZWM_QUEUE_H

--- a/src/queue.h
+++ b/src/queue.h
@@ -31,11 +31,12 @@
 
 #include "type.h"
 
-// clang-format off
+/* clang-format off */
 queue_t *create_queue(void);
-void    enqueue(queue_t *q, node_t *n);
-node_t  *dequeue(queue_t *q);
-bool    is_queue_empty(queue_t *q);
-void    free_queue(queue_t *q);
-// clang-format on
-#endif // ZWM_QUEUE_H
+void enqueue(queue_t *q, node_t *n);
+node_t *dequeue(queue_t *q);
+bool is_queue_empty(queue_t *q);
+void free_queue(queue_t *q);
+/* clang-format on */
+
+#endif /* ZWM_QUEUE_H */

--- a/src/tree.c
+++ b/src/tree.c
@@ -905,17 +905,17 @@ default_layout(node_t *root)
 	if (root == NULL)
 		return;
 
-	rectangle_t	   r = {0};
-	uint16_t	   w = curr_monitor->rectangle.width;
-	uint16_t	   h = curr_monitor->rectangle.height;
-	uint16_t x = curr_monitor->rectangle.x;
-	uint16_t y = curr_monitor->rectangle.y;
+	rectangle_t r = {0};
+	uint16_t	w = curr_monitor->rectangle.width;
+	uint16_t	h = curr_monitor->rectangle.height;
+	uint16_t	x = curr_monitor->rectangle.x;
+	uint16_t	y = curr_monitor->rectangle.y;
 	if (wm->bar && curr_monitor == prim_monitor) {
 		r.x		 = (int16_t)(x + conf.window_gap);
 		r.y		 = (int16_t)(y + wm->bar->rectangle.height + conf.window_gap);
 		r.width	 = (uint16_t)(w - 2 * conf.window_gap - 2 * conf.border_width);
-		r.height = (uint16_t)(h - wm->bar->rectangle.height - 2 * conf.window_gap -
-				   2 * conf.border_width);
+		r.height = (uint16_t)(h - wm->bar->rectangle.height -
+							  2 * conf.window_gap - 2 * conf.border_width);
 	} else {
 		r.x		 = (int16_t)(x + conf.window_gap);
 		r.y		 = (int16_t)(y + conf.window_gap);
@@ -944,19 +944,19 @@ apply_master_layout(node_t *parent)
 		parent->first_child->rectangle = parent->rectangle;
 	} else {
 		rectangle_t r, r2 = {0};
-		r.x		= parent->rectangle.x;
-		r.y		= parent->rectangle.y;
-		r.width = parent->rectangle.width;
-		r.height =
-			(uint16_t)((parent->rectangle.height - (conf.window_gap - conf.border_width)) /
-			2);
+		r.x		  = parent->rectangle.x;
+		r.y		  = parent->rectangle.y;
+		r.width	  = parent->rectangle.width;
+		r.height  = (uint16_t)((parent->rectangle.height -
+								(conf.window_gap - conf.border_width)) /
+							   2);
 
 		r2.x	  = parent->rectangle.x;
 		r2.y	  = (int16_t)(parent->rectangle.y + r.height + conf.window_gap +
 						  conf.border_width);
 		r2.width  = parent->rectangle.width;
-		r2.height = (uint16_t)(parent->rectangle.height - r.height - conf.window_gap -
-					conf.border_width);
+		r2.height = (uint16_t)(parent->rectangle.height - r.height -
+							   conf.window_gap - conf.border_width);
 		parent->first_child->rectangle	= r;
 		parent->second_child->rectangle = r2;
 	}
@@ -995,7 +995,7 @@ master_layout(node_t *root, node_t *n)
 		}
 	}
 
-	n->is_master   = true;
+	n->is_master		 = true;
 
 	/* master rectangle */
 	const rectangle_t r1 = {
@@ -1095,8 +1095,8 @@ stack_layout(node_t *root)
 		r.x		 = (int16_t)(x + conf.window_gap);
 		r.y		 = (int16_t)(y + wm->bar->rectangle.height + conf.window_gap);
 		r.width	 = (uint16_t)(w - 2 * conf.window_gap - 2 * conf.border_width);
-		r.height = (uint16_t)(h - wm->bar->rectangle.height - 2 * conf.window_gap -
-				   2 * conf.border_width);
+		r.height = (uint16_t)(h - wm->bar->rectangle.height -
+							  2 * conf.window_gap - 2 * conf.border_width);
 	} else {
 		r.x		 = (int16_t)(x + conf.window_gap);
 		r.y		 = (int16_t)(y + conf.window_gap);
@@ -1818,7 +1818,6 @@ unlink_node(node_t *n, desktop_t *d)
  * 3. Otherwise:
  *   - Finds a spot in the tree (a leaf), converts it into an internal node,
  *		and then insert the node in there.
- *
  * Note:
  * - Doesn't touch visibility or focus; that's handled outside. */
 bool
@@ -1835,22 +1834,25 @@ transfer_node(node_t *node, desktop_t *d)
 	assert(node->parent == NULL);
 
 	if (is_tree_empty(d->tree)) {
-		rectangle_t	   r = {0};
-		uint16_t	   w = curr_monitor->rectangle.width;
-		uint16_t	   h = curr_monitor->rectangle.height;
-		uint16_t x = curr_monitor->rectangle.x;
-		uint16_t y = curr_monitor->rectangle.y;
+		rectangle_t r = {0};
+		uint16_t	w = curr_monitor->rectangle.width;
+		uint16_t	h = curr_monitor->rectangle.height;
+		uint16_t	x = curr_monitor->rectangle.x;
+		uint16_t	y = curr_monitor->rectangle.y;
 		if (wm->bar && curr_monitor == prim_monitor) {
-			r.x		 = (int16_t)(x + conf.window_gap);
-			r.y		 = (int16_t)(y + wm->bar->rectangle.height + conf.window_gap);
-			r.width	 = (uint16_t)(w - 2 * conf.window_gap - 2 * conf.border_width);
-			r.height = (uint16_t)(h - wm->bar->rectangle.height - 2 * conf.window_gap -
-					   2 * conf.border_width);
+			r.x = (int16_t)(x + conf.window_gap);
+			r.y = (int16_t)(y + wm->bar->rectangle.height + conf.window_gap);
+			r.width =
+				(uint16_t)(w - 2 * conf.window_gap - 2 * conf.border_width);
+			r.height = (uint16_t)(h - wm->bar->rectangle.height -
+								  2 * conf.window_gap - 2 * conf.border_width);
 		} else {
-			r.x		 = (int16_t)(x + conf.window_gap);
-			r.y		 = (int16_t)(y + conf.window_gap);
-			r.width	 = (uint16_t)(w - 2 * conf.window_gap - 2 * conf.border_width);
-			r.height = (uint16_t)(h - 2 * conf.window_gap - 2 * conf.border_width);
+			r.x = (int16_t)(x + conf.window_gap);
+			r.y = (int16_t)(y + conf.window_gap);
+			r.width =
+				(uint16_t)(w - 2 * conf.window_gap - 2 * conf.border_width);
+			r.height =
+				(uint16_t)(h - 2 * conf.window_gap - 2 * conf.border_width);
 		}
 		node->node_type	   = ROOT_NODE;
 		d->tree			   = node;

--- a/src/tree.c
+++ b/src/tree.c
@@ -499,10 +499,10 @@ populate_win_array(node_t *root, xcb_window_t *arr, size_t *index)
 /* stack_and_lower - collects floating windows and optionally lowers
  * non-floating ones.
  *
- * This function goes through the tree and:
- * - Adds floating windows to a stack, and resize the stack if it fills up.
- * - Lowers non-floating windows unless the layout is stacked.
- * - Calls itself on each child node to cover the whole tree. */
+ * goes through the tree and:
+ * - adds floating windows to a stack, and resize the stack if it fills up.
+ * - lowers non-floating windows unless the layout is stacked.
+ * - calls itself on each child node to cover the whole tree. */
 static void
 stack_and_lower(
 	node_t *root, node_t **stack, int *top, int max_size, bool is_stacked)
@@ -816,7 +816,7 @@ find_client_by_window_id(node_t *root, xcb_window_t win)
 
 /* apply_default_layout - applies the default tiling layout to a given tree
  *
- * this function recursively applies the default tiling layout to a node and its
+ * recursively applies the default tiling layout to a node and its
  * descendants in the tree. The default layout splits nodes either
  * vertically or horizontally based on their dimensions. */
 void
@@ -896,7 +896,7 @@ apply_default_layout(node_t *root)
 
 /* default_layout - applies the default layout to the tree.
  *
- * This function initializes the default layout for the entire screen or
+ * initializes the default layout for the entire screen or
  * monitor. It sets up the initial rectangle for the root node with window gaps
  * and border widths in mind, then calls apply_default_layout to recursively
  * layout child nodes. */
@@ -929,7 +929,7 @@ default_layout(node_t *root)
 
 /* apply_master_layout - applies the master layout to a tree.
  *
- * This function implements a master-stack layout, where one window (the master)
+ * implements a master-stack layout, where one window (the master)
  * takes up a larger portion of the screen (70%), and the rest are stacked.
  * TODO: use next_node() to implement this
  */
@@ -973,7 +973,7 @@ apply_master_layout(node_t *parent)
 
 /* master_layout - initializes and applies the master layout to the tree.
  *
- * This function sets up the initial rectangles for the master and stack areas,
+ * This func sets up the initial rectangles for the master and stack areas,
  * marks the appropriate node as the master, and then calls apply_master_layout
  * to recursively apply the layout to the entire tree. */
 static void
@@ -1050,7 +1050,7 @@ master_clean_up(node_t *root)
 
 /* apply_stack_layout - applies the stack layout to a given tree .
  *
- * This function recursively applies the stack layout to a node and its
+ * recursively applies the stack layout to a node and its
  * children in the tree. In a stack layout, all windows occupy
  * the same space, effectively stacking on top of each other. */
 void
@@ -1081,7 +1081,7 @@ apply_stack_layout(node_t *root)
 /**
  * stack_layout - initializes and applies the stack layout to the tree.
  *
- * This function sets up the initial rectangle for the entire stack.
+ * sets up the initial rectangle for the entire stack.
  * It then calls apply_stack_layout to recursively apply the layout
  * to all nodes in the tree. */
 static void
@@ -1113,8 +1113,8 @@ stack_layout(node_t *root)
 
 /* apply_layout - applies the specified layout to the given tree.
  *
- * This function is responsible for switching between different layout
- * types (DEFAULT, MASTER, STACK, GRID) and applying the chosen layout
+ * responsible for switching between different layout
+ * types (DEFAULT, MASTER, STACK) and applying the chosen layout
  * to the desktop's tree. */
 void
 apply_layout(desktop_t *d, layout_t t)
@@ -1759,18 +1759,9 @@ find_any_leaf(node_t *root)
 /* unlink_node - removes a node from the tree while keeping the structure
  * intact.
  *
- * This function cleanly disconnects a node from the tree without freeing its
+ * disconnects a node from the tree without freeing its
  * memory. It tweaks the parent and sibling relationships to keep the tree
- * consistent.
- *
- * what it's being handled:
- * 1. If the node is the root, it essentially clears the tree.
- * 2. If the node has an external sibling:
- *    - The sibling takes over as the parent, and both the unlinked node and the
- * old parent are dropped.
- * 3. If the node has an internal sibling:
- *    - The sibling's children step up to replace the parent, and again, the
- * unlinked node and the old parent are removed.
+ * intact.
  *
  * Note: this function does not free the memory of the unlinked node.
  * The caller is responsible for freeing the memory of the unlinked node if it's
@@ -1819,7 +1810,7 @@ unlink_node(node_t *n, desktop_t *d)
 
 /* transfer_node - moves a node to a new desktop's tree.
  *
- * This function takes a node and places it into the tree of the target desktop.
+ * takes a node and places it into the tree of the target desktop.
  * It handles three main scenarios:
  * 1. If the target tree is empty:
  *   - The node becomes the root of the tree.
@@ -2150,7 +2141,7 @@ is_within_range(rectangle_t *rect1, rectangle_t *rect2, direction_t d)
  * specific direction. It is used to move focus to another node using the
  * keyboard
  *
- * This function searches through the tree (using a bfs) to
+ * searches through the tree (using a bfs) to
  * find the closest external node (a leaf node with a client) that is within a
  * certain range of the given node in the specified direction. It keeps track of
  * the closest node found and returns it.
@@ -2210,7 +2201,7 @@ find_closest_neighbor(node_t *root, node_t *node, direction_t d)
 
 /* cycle_win - cycles focus to the nearest window in a specified direction.
  *
- * This function calls find_closest_neighbor` to get the closest node in the
+ * calls find_closest_neighbor` to get the closest node in the
  * specified direction.
  *
  * If either the root or the neighbor can't be found, it logs an error and

--- a/src/tree.c
+++ b/src/tree.c
@@ -368,18 +368,12 @@ find_node_by_window_id(node_t *root, xcb_window_t win)
 void
 free_tree(node_t *root)
 {
-	if (root == NULL)
+	if (root == NULL) {
 		return;
-
-	if (root->client) {
-		_FREE_(root->client);
 	}
-	node_t *f = root->first_child;
-	free_tree(f);
-	root->first_child = NULL;
-	node_t *s		  = root->second_child;
-	free_tree(s);
-	root->second_child = NULL;
+	free_tree(root->first_child);
+	free_tree(root->second_child);
+	_FREE_(root->client);
 	_FREE_(root);
 }
 

--- a/src/tree.c
+++ b/src/tree.c
@@ -36,7 +36,6 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <time.h>
 #include <xcb/xcb.h>
 #include <xcb/xcb_icccm.h>
 
@@ -909,19 +908,19 @@ default_layout(node_t *root)
 	rectangle_t	   r = {0};
 	uint16_t	   w = curr_monitor->rectangle.width;
 	uint16_t	   h = curr_monitor->rectangle.height;
-	const uint16_t x = curr_monitor->rectangle.x;
-	const uint16_t y = curr_monitor->rectangle.y;
+	uint16_t x = curr_monitor->rectangle.x;
+	uint16_t y = curr_monitor->rectangle.y;
 	if (wm->bar && curr_monitor == prim_monitor) {
-		r.x		 = x + conf.window_gap;
-		r.y		 = y + wm->bar->rectangle.height + conf.window_gap;
-		r.width	 = w - 2 * conf.window_gap - 2 * conf.border_width;
-		r.height = h - wm->bar->rectangle.height - 2 * conf.window_gap -
-				   2 * conf.border_width;
+		r.x		 = (int16_t)(x + conf.window_gap);
+		r.y		 = (int16_t)(y + wm->bar->rectangle.height + conf.window_gap);
+		r.width	 = (uint16_t)(w - 2 * conf.window_gap - 2 * conf.border_width);
+		r.height = (uint16_t)(h - wm->bar->rectangle.height - 2 * conf.window_gap -
+				   2 * conf.border_width);
 	} else {
-		r.x		 = x + conf.window_gap;
-		r.y		 = y + conf.window_gap;
-		r.width	 = w - 2 * conf.window_gap - 2 * conf.border_width;
-		r.height = h - 2 * conf.window_gap - 2 * conf.border_width;
+		r.x		 = (int16_t)(x + conf.window_gap);
+		r.y		 = (int16_t)(y + conf.window_gap);
+		r.width	 = (uint16_t)(w - 2 * conf.window_gap - 2 * conf.border_width);
+		r.height = (uint16_t)(h - 2 * conf.window_gap - 2 * conf.border_width);
 	}
 	root->rectangle = r;
 	apply_default_layout(root);
@@ -949,15 +948,15 @@ apply_master_layout(node_t *parent)
 		r.y		= parent->rectangle.y;
 		r.width = parent->rectangle.width;
 		r.height =
-			(parent->rectangle.height - (conf.window_gap - conf.border_width)) /
-			2;
+			(uint16_t)((parent->rectangle.height - (conf.window_gap - conf.border_width)) /
+			2);
 
 		r2.x	  = parent->rectangle.x;
 		r2.y	  = (int16_t)(parent->rectangle.y + r.height + conf.window_gap +
 						  conf.border_width);
 		r2.width  = parent->rectangle.width;
-		r2.height = parent->rectangle.height - r.height - conf.window_gap -
-					conf.border_width;
+		r2.height = (uint16_t)(parent->rectangle.height - r.height - conf.window_gap -
+					conf.border_width);
 		parent->first_child->rectangle	= r;
 		parent->second_child->rectangle = r2;
 	}
@@ -984,7 +983,7 @@ master_layout(node_t *root, node_t *n)
 	const uint16_t h			= curr_monitor->rectangle.height;
 	const uint16_t x			= curr_monitor->rectangle.x;
 	const uint16_t y			= curr_monitor->rectangle.y;
-	const uint16_t master_width = w * ratio;
+	const uint16_t master_width = (uint16_t)(w * ratio);
 	const uint16_t r_width		= (uint16_t)(w * (1 - ratio));
 	const uint16_t bar_height = wm->bar == NULL ? 0 : wm->bar->rectangle.height;
 
@@ -999,16 +998,16 @@ master_layout(node_t *root, node_t *n)
 	n->is_master   = true;
 
 	/* master rectangle */
-	rectangle_t r1 = {
-		.x		= x + conf.window_gap,
+	const rectangle_t r1 = {
+		.x		= (int16_t)(x + conf.window_gap),
 		.y		= (int16_t)(y + bar_height + conf.window_gap),
 		.width	= (uint16_t)(master_width - 2 * conf.window_gap),
 		.height = (uint16_t)(h - 2 * conf.window_gap - bar_height),
 	};
 
 	/* stack rectangle */
-	rectangle_t r2 = {
-		.x		= (x + master_width),
+	const rectangle_t r2 = {
+		.x		= (int16_t)(x + master_width),
 		.y		= (int16_t)(y + bar_height + conf.window_gap),
 		.width	= (uint16_t)(r_width - (1 * conf.window_gap)),
 		.height = (uint16_t)(h - 2 * conf.window_gap - bar_height),
@@ -1020,7 +1019,7 @@ master_layout(node_t *root, node_t *n)
 	if (n->node_type == ROOT_NODE && n->first_child == NULL &&
 		n->second_child == NULL) {
 		n->rectangle = (rectangle_t){
-			.x		= x + conf.window_gap,
+			.x		= (int16_t)(x + conf.window_gap),
 			.y		= (int16_t)(y + bar_height + conf.window_gap),
 			.width	= (uint16_t)(w - 2 * conf.window_gap),
 			.height = (uint16_t)(h - 2 * conf.window_gap - bar_height),
@@ -1093,16 +1092,16 @@ stack_layout(node_t *root)
 	const uint16_t x = curr_monitor->rectangle.x;
 	const uint16_t y = curr_monitor->rectangle.y;
 	if (wm->bar && curr_monitor == prim_monitor) {
-		r.x		 = x + conf.window_gap;
-		r.y		 = y + wm->bar->rectangle.height + conf.window_gap;
-		r.width	 = w - 2 * conf.window_gap - 2 * conf.border_width;
-		r.height = h - wm->bar->rectangle.height - 2 * conf.window_gap -
-				   2 * conf.border_width;
+		r.x		 = (int16_t)(x + conf.window_gap);
+		r.y		 = (int16_t)(y + wm->bar->rectangle.height + conf.window_gap);
+		r.width	 = (uint16_t)(w - 2 * conf.window_gap - 2 * conf.border_width);
+		r.height = (uint16_t)(h - wm->bar->rectangle.height - 2 * conf.window_gap -
+				   2 * conf.border_width);
 	} else {
-		r.x		 = x + conf.window_gap;
-		r.y		 = y + conf.window_gap;
-		r.width	 = w - 2 * conf.window_gap - 2 * conf.border_width;
-		r.height = h - 2 * conf.window_gap - 2 * conf.border_width;
+		r.x		 = (int16_t)(x + conf.window_gap);
+		r.y		 = (int16_t)(y + conf.window_gap);
+		r.width	 = (uint16_t)(w - 2 * conf.window_gap - 2 * conf.border_width);
+		r.height = (uint16_t)(h - 2 * conf.window_gap - 2 * conf.border_width);
 	}
 	root->rectangle = r;
 	apply_stack_layout(root);
@@ -1839,19 +1838,19 @@ transfer_node(node_t *node, desktop_t *d)
 		rectangle_t	   r = {0};
 		uint16_t	   w = curr_monitor->rectangle.width;
 		uint16_t	   h = curr_monitor->rectangle.height;
-		const uint16_t x = curr_monitor->rectangle.x;
-		const uint16_t y = curr_monitor->rectangle.y;
+		uint16_t x = curr_monitor->rectangle.x;
+		uint16_t y = curr_monitor->rectangle.y;
 		if (wm->bar && curr_monitor == prim_monitor) {
-			r.x		 = x + conf.window_gap;
-			r.y		 = y + wm->bar->rectangle.height + conf.window_gap;
-			r.width	 = w - 2 * conf.window_gap - 2 * conf.border_width;
-			r.height = h - wm->bar->rectangle.height - 2 * conf.window_gap -
-					   2 * conf.border_width;
+			r.x		 = (int16_t)(x + conf.window_gap);
+			r.y		 = (int16_t)(y + wm->bar->rectangle.height + conf.window_gap);
+			r.width	 = (uint16_t)(w - 2 * conf.window_gap - 2 * conf.border_width);
+			r.height = (uint16_t)(h - wm->bar->rectangle.height - 2 * conf.window_gap -
+					   2 * conf.border_width);
 		} else {
-			r.x		 = x + conf.window_gap;
-			r.y		 = y + conf.window_gap;
-			r.width	 = w - 2 * conf.window_gap - 2 * conf.border_width;
-			r.height = h - 2 * conf.window_gap - 2 * conf.border_width;
+			r.x		 = (int16_t)(x + conf.window_gap);
+			r.y		 = (int16_t)(y + conf.window_gap);
+			r.width	 = (uint16_t)(w - 2 * conf.window_gap - 2 * conf.border_width);
+			r.height = (uint16_t)(h - 2 * conf.window_gap - 2 * conf.border_width);
 		}
 		node->node_type	   = ROOT_NODE;
 		d->tree			   = node;

--- a/src/tree.c
+++ b/src/tree.c
@@ -45,13 +45,13 @@
 #include "type.h"
 #include "zwm.h"
 
-// clang-format off
+/* clang-format off */
 static void master_layout(node_t *parent, node_t *);
 static void stack_layout(node_t *parent);
 static void default_layout(node_t *parent);
 static node_t *find_tree_root(node_t *);
 static bool is_parent_null(const node_t *node);
-// clang-format on
+/* clang-format on */
 
 node_t *
 create_node(client_t *c)
@@ -1394,7 +1394,7 @@ delete_node(node_t *node, desktop_t *d)
 		_LOG_(ERROR, "could not unlink node.. abort");
 		return;
 	}
-	
+
 	if (check) {
 		assert(!d->tree);
 	}

--- a/src/tree.h
+++ b/src/tree.h
@@ -41,7 +41,8 @@ node_t   *cycle_win(node_t *node, direction_t);
 node_t   *find_left_leaf(node_t *root);
 node_t   *find_any_leaf(node_t *root);
 node_t 	 *get_focused_node(node_t *n);
-void     unlink_node(node_t *node, desktop_t *d);
+bool     unlink_node(node_t *node, desktop_t *d);
+void     horizontal_resize(node_t *n, resize_t t);
 void 	 apply_master_layout(node_t *parent);
 void 	 apply_default_layout(node_t *root);
 void	 apply_stack_layout(node_t *root);
@@ -54,16 +55,15 @@ void	 restack(void);
 void     restackv2(node_t *root);
 void	 delete_node(node_t *node, desktop_t *d);
 void	 insert_node(node_t *current_node, node_t *new_node, layout_t layout);
+void     arrange_tree(node_t *tree, layout_t l);
 void	 log_tree_nodes(node_t *node);
-void	 transfer_node(node_t *, desktop_t *);
+bool	 transfer_node(node_t *, desktop_t *);
 bool	 is_tree_empty(const node_t *root);
 bool	 client_exist(node_t *cn, xcb_window_t id);
 bool	 has_floating_window(node_t *root);
 int	   	 render_tree(node_t *current_node);
 int		 hide_windows(node_t *tree);
 int 	 show_windows(node_t *tree);
-int	     transfer_node_wrapper(arg_t *arg);
-int 	 horizontal_resize_wrapper(arg_t *arg);
 int	     swap_node(node_t *root);
 // clang-format on
 #endif // ZWM_TREE_H

--- a/src/tree.h
+++ b/src/tree.h
@@ -30,40 +30,40 @@
 #define ZWM_TREE_H
 
 #include "type.h"
-// clang-format off
-node_t   *create_node(client_t *c);
-node_t   *init_root(void);
-node_t   *find_node_by_window_id(node_t *root, xcb_window_t window_id);
-node_t   *find_master_node(node_t *root);
-node_t   *prev_node(node_t *current);
-node_t   *next_node(node_t *current);
-node_t   *cycle_win(node_t *node, direction_t);
-node_t   *find_left_leaf(node_t *root);
-node_t   *find_any_leaf(node_t *root);
-node_t 	 *get_focused_node(node_t *n);
-bool     unlink_node(node_t *node, desktop_t *d);
-void     horizontal_resize(node_t *n, resize_t t);
-void 	 apply_master_layout(node_t *parent);
-void 	 apply_default_layout(node_t *root);
-void	 apply_stack_layout(node_t *root);
-void	 update_focus(node_t *root, node_t *n);
-void	 flip_node(node_t *node);
-void	 resize_subtree(node_t *parent);
-void	 apply_layout(desktop_t *d, layout_t t);
-void	 free_tree(node_t *root);
-void	 restack(void);
-void     restackv2(node_t *root);
-void	 delete_node(node_t *node, desktop_t *d);
-void	 insert_node(node_t *current_node, node_t *new_node, layout_t layout);
-void     arrange_tree(node_t *tree, layout_t l);
-void	 log_tree_nodes(node_t *node);
-bool	 transfer_node(node_t *, desktop_t *);
-bool	 is_tree_empty(const node_t *root);
-bool	 client_exist(node_t *cn, xcb_window_t id);
-bool	 has_floating_window(node_t *root);
-int	   	 render_tree(node_t *current_node);
-int		 hide_windows(node_t *tree);
-int 	 show_windows(node_t *tree);
-int	     swap_node(node_t *root);
-// clang-format on
-#endif // ZWM_TREE_H
+/* clang-format off */
+node_t *create_node(client_t *c);
+node_t *init_root(void);
+node_t *find_node_by_window_id(node_t *root, xcb_window_t window_id);
+node_t *find_master_node(node_t *root);
+node_t *prev_node(node_t *current);
+node_t *next_node(node_t *current);
+node_t *cycle_win(node_t *node, direction_t);
+node_t *find_left_leaf(node_t *root);
+node_t *find_any_leaf(node_t *root);
+node_t *get_focused_node(node_t *n);
+bool unlink_node(node_t *node, desktop_t *d);
+void horizontal_resize(node_t *n, resize_t t);
+void apply_master_layout(node_t *parent);
+void apply_default_layout(node_t *root);
+void apply_stack_layout(node_t *root);
+void update_focus(node_t *root, node_t *n);
+void flip_node(node_t *node);
+void resize_subtree(node_t *parent);
+void apply_layout(desktop_t *d, layout_t t);
+void free_tree(node_t *root);
+void restack(void);
+void restackv2(node_t *root);
+void delete_node(node_t *node, desktop_t *d);
+void insert_node(node_t *current_node, node_t *new_node, layout_t layout);
+void arrange_tree(node_t *tree, layout_t l);
+void log_tree_nodes(node_t *node);
+bool transfer_node(node_t *, desktop_t *);
+bool is_tree_empty(const node_t *root);
+bool client_exist(node_t *cn, xcb_window_t id);
+bool has_floating_window(node_t *root);
+int render_tree(node_t *current_node);
+int hide_windows(node_t *tree);
+int show_windows(node_t *tree);
+int swap_node(node_t *root);
+/* clang-format off */
+#endif /* ZWM_TREE_H */

--- a/src/type.h
+++ b/src/type.h
@@ -91,6 +91,15 @@ typedef enum {
 	CURSOR_MAX
 } cursor_t;
 
+/* bit flags to detrmine the change in monitors' state */
+typedef enum {
+	_NONE		 = 0x00,
+	CONNECTED	 = 0x01,
+	DISCONNECTED = 0x02,
+	/* LAYOUT includes resolution, position, or orientation changes */
+	LAYOUT		 = 0x04
+} monitor_state_t;
+
 typedef struct {
 	// 2^16 = 65535
 	uint16_t previous_x, previous_y;
@@ -129,55 +138,6 @@ typedef enum {
 	INTERNAL_NODE,
 	EXTERNAL_NODE
 } node_type_t;
-
-// clang-format off
-/*
-		I         ROOT (root is also an INTERNAL NODE, unless it is a leaf by definition)
-	  /   \
-	 I     I      INTERNAL NODES
-	/     / \
-   E     E   E    EXTERNAL NODES (or leaves)
-
-	I (if parent of E) = screen sections/partitions in which windows can be mapped
-	(displayed). E = windows in every screen partition. windows are basically the
-	leaves of a full binary tree. E nodes, on the screen, evenly share the width &
-	height of their I parent, and the I's x & y as well.
-
-		I
-	  /   \
-	 I     I
-	/     / \
-   E     E   I
-			/ \
-		   E   E
-
-	[I] partitions/sections can be:
-	1- container of other partitions
-	2- contained by other partitions
-
-	- the behaviour should be ->
-	- 1,2,3 are leaves (EXTERNAL_NODE) 
-	- a,b are internal nodes (INTERNAL_NODE), or screen sections/partitions
-
-			 1                          a                          a
-			 ^                         / \                        / \
-						 --->         1   2         --->         1   b
-										  ^                         / \
-																   2   3
-																	   ^
-
-	+-----------------------+  +-----------------------+  +-----------------------+
-	|                       |  |           |           |  |           |           |
-	|                       |  |           |           |  |           |     2     |
-	|                       |  |           |           |  |           |           |
-	|           1           |  |     1     |     2     |  |     1     |-----------|
-	|           ^           |  |           |     ^     |  |           |           |
-	|                       |  |           |           |  |           |     3     |
-	|                       |  |           |           |  |           |     ^     |
-	+-----------------------+  +-----------------------+  +-----------------------+
-
-*/
-// clang-format on
 
 typedef struct node_t node_t;
 struct node_t {
@@ -285,4 +245,16 @@ struct rule_t {
 	int		desktop_id;
 	rule_t *next;
 };
+
+typedef struct queue_node_t queue_node_t;
+struct queue_node_t {
+	node_t		 *tree_node;
+	queue_node_t *next;
+};
+
+typedef struct {
+	queue_node_t *front;
+	queue_node_t *rear;
+} queue_t;
+
 #endif // ZWM_TYPE_H

--- a/src/type.h
+++ b/src/type.h
@@ -37,16 +37,16 @@
 #include <xcb/xcb_ewmh.h>
 
 #define CAP					 3
-#define W_GAP				 10
 #define MAXLEN				 (2 << 7)
 #define DLEN				 (2 << 4)
-#define NULL_STR			 "N/A"
-#define MONITOR_NAME		 "DEF_MONITOR"
-#define ROOT_WINDOW			 "root ZWM"
-#define NORMAL_BORDER_COLOR	 0x30302f
-#define ACTIVE_BORDER_COLOR	 0x83a598
-#define BORDER_WIDTH		 2
-#define FOCUS_FOLLOW_POINTER true
+#define NULL_STR			 "N/A"		   /* default null string value */
+#define MONITOR_NAME		 "DEF_MONITOR" /* default monitor name */
+#define ROOT_WINDOW			 "root ZWM"	   /* root window name */
+#define W_GAP				 10			   /* default window gap */
+#define NORMAL_BORDER_COLOR	 0x30302f	   /* default inactive border color */
+#define ACTIVE_BORDER_COLOR	 0x83a598	   /* default active border color */
+#define BORDER_WIDTH		 2			   /* default border width */
+#define FOCUS_FOLLOW_POINTER true		   /* default focus follows mouse */
 
 typedef xcb_connection_t xcb_conn_t;
 
@@ -62,16 +62,16 @@ typedef enum {
 } flip_t;
 
 typedef enum {
-	GROW = 1 << 1,
-	SHRINK
+	GROW = 1, /* increase window size */
+	SHRINK	  /* decrease window size */
 } resize_t;
 
 typedef enum {
-	LEFT = 1 << 1,
-	RIGHT,
-	UP,
-	DOWN,
-	NONE
+	LEFT = 1, /* move/resize left */
+	RIGHT,	  /* move/resize right */
+	UP,		  /* move/resize up */
+	DOWN,	  /* move/resize down */
+	NONE	  /* no direction */
 } direction_t;
 
 typedef enum {
@@ -81,31 +81,36 @@ typedef enum {
 	WARNING
 } log_level_t;
 
+/* predefined cursor types */
 typedef enum {
-	CURSOR_POINTER = 0,
-	CURSOR_WATCH,
-	CURSOR_MOVE,
-	CURSOR_XTERM,
-	CURSOR_NOT_ALLOWED,
-	CURSOR_HAND2,
-	CURSOR_MAX
+	CURSOR_POINTER = 0, /* standard pointer */
+	CURSOR_WATCH,		/* busy/wait cursor */
+	CURSOR_MOVE,		/* move window cursor */
+	CURSOR_XTERM,		/* text selection cursor, i think */
+	CURSOR_NOT_ALLOWED, /* action not permitted */
+	CURSOR_HAND2,		/* clickable item cursor */
+	CURSOR_MAX			/* maximum cursor types */
 } cursor_t;
 
-/* bit flags to detrmine the change in monitors' state */
+/* bit flags to determine the change in monitors' state */
 typedef enum {
-	_NONE		 = 0x00,
-	CONNECTED	 = 0x01,
-	DISCONNECTED = 0x02,
-	/* LAYOUT includes resolution, position, or orientation changes */
-	LAYOUT		 = 0x04
+	_NONE		 = (1 << 0), /* 00000001  no state change */
+	CONNECTED	 = (1 << 1), /* 00000010  monitor connected */
+	DISCONNECTED = (1 << 2), /* 00000100  monitor disconnected */
+	LAYOUT		 = (1 << 3), /* 00001000  layout changed */
+	/* note: layout also indcates changes in resoltuions, positions, or scale
+	 * and oreintation */
 } monitor_state_t;
 
 typedef struct {
-	// 2^16 = 65535
 	uint16_t previous_x, previous_y;
 	uint16_t current_x, current_y;
 } posxy_t;
 
+/* defines a rectangle (the window area or the tile/section area).
+ * note: x and y can be signed (negative or positive), for example when a
+ * portion of a window goes out of the visible area of the screen.
+ */
 typedef struct {
 	int16_t	 x;
 	int16_t	 y;
@@ -114,18 +119,33 @@ typedef struct {
 } rectangle_t;
 
 typedef enum {
-	TILED,
-	FLOATING,
-	FULLSCREEN
+	TILED,	   /* automatically tiled */
+	FLOATING,  /* freely movable */
+	FULLSCREEN /* occupies entire screen */
 } state_t;
 
 typedef enum {
-	DEFAULT = 1 << 1,
-	MASTER,
-	STACK,
-	GRID
+	DEFAULT = 1, /* standard manual tiling */
+	MASTER,		 /* master-stack layout */
+	STACK,		 /* stacked windows */
+	GRID		 /* grid-based layout */
 } layout_t;
 
+typedef enum {
+	WINDOW_TYPE_NORMAL		 = 1,
+	WINDOW_TYPE_DOCK		 = 2,
+	WINDOW_TYPE_TOOLBAR_MENU = 3,
+	WINDOW_TYPE_UTILITY		 = 4,
+	WINDOW_TYPE_SPLASH		 = 5,
+	WINDOW_TYPE_DIALOG		 = 6,
+	WINDOW_TYPE_NOTIFICATION = 7,
+	WINDOW_TYPE_UNKNOWN		 = -1
+} ewmh_window_type_t;
+
+/* defines the client, like an opened application like firefox of a text editor.
+ * every leaf node in the tree contains a non-null client, internal nodes ALWAYS
+ * have null clients.
+ */
 typedef struct {
 	uint32_t	 border_width;
 	xcb_window_t window;
@@ -133,128 +153,162 @@ typedef struct {
 	state_t		 state;
 } client_t;
 
+/* types for tree nodes */
 typedef enum {
-	ROOT_NODE = 1 << 1,
-	INTERNAL_NODE,
-	EXTERNAL_NODE
+	ROOT_NODE = 1, /* root usually holds the full rectangle of the screen */
+	INTERNAL_NODE, /* internal nodes hold screen sections/tiles only */
+	EXTERNAL_NODE  /* external nodes hold the actual windows */
 } node_type_t;
 
+/* the definition of the tree node */
 typedef struct node_t node_t;
 struct node_t {
-	node_t	   *parent;
+	node_t	   *parent; /* a pointer to the parent, needed when traversing up */
 	node_t	   *first_child;
 	node_t	   *second_child;
-	client_t   *client;
-	node_type_t node_type;
-	rectangle_t rectangle;
+	client_t   *client; /* the actual window this node hold, if it's a leaf */
+	node_type_t node_type; /* node type */
+	rectangle_t rectangle; /* the position and size for this node */
 	rectangle_t floating_rectangle;
-	bool		is_focused;
-	bool		is_master;
+	bool		is_focused; /* whether or not this guy is focused */
+	bool		is_master;	/* whether this node is the master node */
 };
 
+/* the defintion of a desktop.
+ * each desktop has its own tree and layout.
+ * the wm could have up to 10 desktops.
+ */
 typedef struct {
-	node_t	*tree;
-	char	 name[DLEN];
-	uint8_t	 id;
-	uint8_t	 n_count;
-	layout_t layout;
-	bool	 is_focused;
+	node_t	*tree;		 /* the tree in this desktop */
+	char	 name[DLEN]; /* the name, it stringfeis the index of this desktop */
+	uint8_t	 id;		 /* the number of this desktop */
+	uint8_t	 n_count;	 /* the number of active windows/external nodes */
+	layout_t layout;	 /* the layout (master, default, stack) */
+	bool	 is_focused; /* whether this is focused, only focused desktops
+						  * are rendered */
 } desktop_t;
 
+/* monitor representation (also a linked list of monitors).
+ * It is a physical output on your graphics driver, and it usually corresponds
+ * to one connected screen.
+ * Each monitore has its own virtual desktops by default */
 typedef struct monitor_t monitor_t;
 struct monitor_t {
-	desktop_t		 **desktops;
-	monitor_t		  *next;
-	char			   name[DLEN];
-	uint32_t		   id;
-	xcb_randr_output_t randr_id;
-	xcb_window_t	   root;
-	rectangle_t		   rectangle;
-	bool			   is_wired;
-	bool			   is_focused;
-	bool			   is_occupied;
-	bool			   is_primary;
-	uint8_t			   n_of_desktops;
+	desktop_t		 **desktops;	/* array of desktops */
+	monitor_t		  *next;		/* next monitor in list */
+	char			   name[DLEN];	/* monitor name (e.g. HDMI or eDP) */
+	uint32_t		   id;			/* monitor identifier, used with xinerama */
+	xcb_randr_output_t randr_id;	/* randr output id, used with xrnadr */
+	xcb_window_t	   root;		/* the root window on this monitor */
+	rectangle_t		   rectangle;	/* monitor dimensions */
+	bool			   is_wired;	/* connection status */
+	bool			   is_focused;	/* focus status */
+	bool			   is_occupied; /* window presence */
+	bool			   is_primary;	/* primary monitor */
+	uint8_t			   n_of_desktops; /* total desktops, defined in
+									   * the config file  */
 };
 
+/* status bar representation */
 typedef struct {
-	uint32_t	 id;
-	xcb_window_t window;
-	rectangle_t	 rectangle;
+	uint32_t	 id;		/* bar identifier */
+	xcb_window_t window;	/* xcb window reference */
+	rectangle_t	 rectangle; /* bar dimensions */
 } bar_t;
 
+/* window manager global state */
 typedef struct {
-	xcb_connection_t	  *connection;
-	xcb_ewmh_connection_t *ewmh;
-	xcb_screen_t		  *screen;
-	bar_t				  *bar;
-	xcb_window_t		   root_window;
-	split_type_t		   split_type;
-	uint8_t				   screen_nbr;
+	xcb_connection_t	  *connection; /* xcb connection */
+	xcb_ewmh_connection_t *ewmh;	   /* ewmh connection */
+	xcb_screen_t		  *screen;	   /* global screen */
+	bar_t				  *bar;		   /* status bar, should be moved (FIXME) */
+	xcb_window_t		   root_window; /* root window */
+	split_type_t		   split_type;	/* current split type */
+	uint8_t				   screen_nbr;	/* screen number */
 } wm_t;
 
+/* argument structure for key bindings */
 typedef struct {
-	char	  **cmd;
-	uint8_t		argc;
-	uint8_t		idx;
-	resize_t	r;
-	layout_t	t;
-	direction_t d;
-	state_t		s;
+	char	  **cmd;  /* command arguments, used for execp family actions */
+	uint8_t		argc; /* argument count */
+	uint8_t		idx;  /* target index, used for desktop switching */
+	resize_t	r;	  /* resize operation */
+	layout_t	t;	  /* layout type */
+	direction_t d;	  /* movement direction */
+	state_t		s;	  /* window state, used to change window state */
 } arg_t;
 
+/* key binding structure. used for the global fallback array in zwm.c */
 typedef struct {
-	uint32_t	 mod;
-	xcb_keysym_t keysym;
-	int (*function_ptr)(arg_t *);
-	arg_t *arg;
+	uint32_t	 mod;			  /* modifier key */
+	xcb_keysym_t keysym;		  /* key symbol */
+	int (*function_ptr)(arg_t *); /* action function */
+	arg_t *arg;					  /* function arguments */
 } _key__t;
 
+/* config key structure (linked list),
+ * repesents the keys in the config file
+ */
 typedef struct conf_key_t conf_key_t;
 struct conf_key_t {
-	uint32_t	 mod;
-	xcb_keysym_t keysym;
-	int (*function_ptr)(arg_t *);
-	arg_t	   *arg;
-	conf_key_t *next;
+	uint32_t	 mod;			  /* modifier key */
+	xcb_keysym_t keysym;		  /* key symbol */
+	int (*function_ptr)(arg_t *); /* action function */
+	arg_t	   *arg;			  /* function arguments */
+	conf_key_t *next;			  /* next key */
 };
 
+/* function mapping structure */
 typedef struct {
-	char *func_name;
-	int (*function_ptr)(arg_t *);
+	char *func_name;			  /* function name */
+	int (*function_ptr)(arg_t *); /* function pointer */
 } conf_mapper_t;
 
+/* key mapping structure */
 typedef struct {
-	char		 key[6];
-	xcb_keysym_t keysym;
+	char		 key[6]; /* key representation */
+	xcb_keysym_t keysym; /* key symbol */
 } key_mapper_t;
 
+/* window manager configuration */
 typedef struct {
-	uint16_t border_width;
-	uint16_t window_gap;
-	uint32_t active_border_color;
-	uint32_t normal_border_color;
-	int		 virtual_desktops;
-	bool	 focus_follow_pointer;
+	uint16_t border_width;		   /* window border width */
+	uint16_t window_gap;		   /* spacing between windows */
+	uint32_t active_border_color;  /* focused window border color */
+	uint32_t normal_border_color;  /* unfocused window border color */
+	int		 virtual_desktops;	   /* number of virtual desktops */
+	bool	 focus_follow_pointer; /* mouse focus tracking */
 } config_t;
 
+/* window rule structure (linked list) */
 typedef struct rule_t rule_t;
 struct rule_t {
-	char	win_name[256];
-	state_t state;
-	int		desktop_id;
-	rule_t *next;
+	char	win_name[256]; /* window name pattern */
+	state_t state;		   /* default window state */
+	int		desktop_id;	   /* target desktop, if desired */
+	rule_t *next;		   /* next rule in list */
 };
 
+/* queue node */
 typedef struct queue_node_t queue_node_t;
 struct queue_node_t {
-	node_t		 *tree_node;
-	queue_node_t *next;
+	node_t		 *tree_node; /* tree node reference */
+	queue_node_t *next;		 /* next queue node */
 };
 
+/* queue structure for level-order tree traversal */
 typedef struct {
-	queue_node_t *front;
-	queue_node_t *rear;
+	queue_node_t *front; /* front of queue */
+	queue_node_t *rear;	 /* rear of queue */
 } queue_t;
+
+/* event handler function pointer type */
+typedef int (*event_handler_t)(const xcb_generic_event_t *);
+
+/* event handler registration structure */
+typedef struct {
+	uint8_t			type;
+	event_handler_t handler;
+} event_handler_entry_t;
 
 #endif // ZWM_TYPE_H

--- a/src/type.h
+++ b/src/type.h
@@ -313,4 +313,4 @@ typedef struct {
 	int (*handle)(const xcb_generic_event_t *);
 } event_handler_entry_t;
 
-#endif // ZWM_TYPE_H
+#endif /* ZWM_TYPE_H */

--- a/src/type.h
+++ b/src/type.h
@@ -212,8 +212,8 @@ struct node_t {
 typedef struct {
 	node_t	*tree;		 /* the tree in this desktop */
 	char	 name[DLEN]; /* the name, it stringfeis the index of this desktop */
-	uint8_t	 id;		 /* the number of this desktop */
-	uint8_t	 n_count;	 /* the number of active windows/external nodes */
+	uint16_t id;		 /* the number of this desktop */
+	uint16_t n_count;	 /* the number of active windows/external nodes */
 	layout_t layout;	 /* the layout (master, default, stack) */
 	bool	 is_focused; /* whether this is focused, only focused desktops
 						  * are rendered */
@@ -236,7 +236,7 @@ struct monitor_t {
 	bool			   is_focused;	/* focus status */
 	bool			   is_occupied; /* window presence */
 	bool			   is_primary;	/* primary monitor */
-	uint8_t			   n_of_desktops; /* total desktops, defined in
+	uint16_t		   n_of_desktops; /* total desktops, defined in
 									   * the config file  */
 };
 
@@ -278,7 +278,7 @@ typedef struct {
 } _key__t;
 
 /* config key structure (linked list),
- * repesents the keys in the config file
+ * represents the keys in the config file
  */
 typedef struct conf_key_t conf_key_t;
 struct conf_key_t {

--- a/src/type.h
+++ b/src/type.h
@@ -48,7 +48,12 @@
 #define BORDER_WIDTH		 2			   /* default border width */
 #define FOCUS_FOLLOW_POINTER true		   /* default focus follows mouse */
 
-typedef xcb_connection_t xcb_conn_t;
+/* type aliases */
+typedef xcb_connection_t	  xcb_conn_t;
+typedef xcb_generic_error_t	  xcb_error_t;
+typedef xcb_void_cookie_t	  xcb_cookie_t;
+typedef xcb_ewmh_connection_t xcb_ewmh_conn_t;
+typedef xcb_generic_event_t	  xcb_event_t;
 
 typedef enum {
 	HORIZONTAL_TYPE,
@@ -240,10 +245,10 @@ typedef struct {
 
 /* key binding structure. used for the global fallback array in zwm.c */
 typedef struct {
-	uint32_t	 mod;			  /* modifier key */
-	xcb_keysym_t keysym;		  /* key symbol */
-	int (*function_ptr)(arg_t *); /* action function */
-	arg_t *arg;					  /* function arguments */
+	uint32_t	 mod;		 /* modifier key */
+	xcb_keysym_t keysym;	 /* key symbol */
+	int (*execute)(arg_t *); /* action function */
+	arg_t *arg;				 /* function arguments */
 } _key__t;
 
 /* config key structure (linked list),
@@ -251,17 +256,17 @@ typedef struct {
  */
 typedef struct conf_key_t conf_key_t;
 struct conf_key_t {
-	uint32_t	 mod;			  /* modifier key */
-	xcb_keysym_t keysym;		  /* key symbol */
-	int (*function_ptr)(arg_t *); /* action function */
-	arg_t	   *arg;			  /* function arguments */
-	conf_key_t *next;			  /* next key */
+	uint32_t	 mod;		 /* modifier key */
+	xcb_keysym_t keysym;	 /* key symbol */
+	int (*execute)(arg_t *); /* action function */
+	arg_t	   *arg;		 /* function arguments */
+	conf_key_t *next;		 /* next key */
 };
 
 /* function mapping structure */
 typedef struct {
-	char *func_name;			  /* function name */
-	int (*function_ptr)(arg_t *); /* function pointer */
+	char *func_name;		 /* function name */
+	int (*execute)(arg_t *); /* function pointer */
 } conf_mapper_t;
 
 /* key mapping structure */
@@ -302,13 +307,10 @@ typedef struct {
 	queue_node_t *rear;	 /* rear of queue */
 } queue_t;
 
-/* event handler function pointer type */
-typedef int (*event_handler_t)(const xcb_generic_event_t *);
-
 /* event handler registration structure */
 typedef struct {
-	uint8_t			type;
-	event_handler_t handler;
+	uint8_t type;
+	int (*handle)(const xcb_generic_event_t *);
 } event_handler_entry_t;
 
 #endif // ZWM_TYPE_H

--- a/src/type.h
+++ b/src/type.h
@@ -147,6 +147,32 @@ typedef enum {
 	WINDOW_TYPE_UNKNOWN		 = -1
 } ewmh_window_type_t;
 
+typedef enum {
+	STATE_UNSUPPORTED = 0,
+	STATE_FULLSCREEN,
+	STATE_BELOW,
+	STATE_ABOVE,
+	STATE_HIDDEN,
+	STATE_STICKY,
+	STATE_DEMANDS_ATTENTION
+} window_state_type_t;
+
+typedef enum {
+	STATE_ACTION_INVALID = 0,
+	STATE_ACTION_REMOVE,
+	STATE_ACTION_ADD,
+	STATE_ACTION_TOGGLE
+} window_state_action_t;
+
+typedef enum {
+	CLIENT_MESSAGE_UNSUPPORTED = 0,
+	CLIENT_MESSAGE_CURRENT_DESKTOP,
+	CLIENT_MESSAGE_WINDOW_STATE,
+	CLIENT_MESSAGE_ACTIVE_WINDOW,
+	CLIENT_MESSAGE_WINDOW_DESKTOP,
+	CLIENT_MESSAGE_CLOSE_WINDOW
+} client_message_type_t;
+
 /* defines the client, like an opened application like firefox of a text editor.
  * every leaf node in the tree contains a non-null client, internal nodes ALWAYS
  * have null clients.

--- a/src/zwm.c
+++ b/src/zwm.c
@@ -51,35 +51,42 @@
 #include <xcb/xinerama.h>
 #include <xcb/xproto.h>
 
-#define WINDOW_X				 XCB_CONFIG_WINDOW_X
-#define WINDOW_Y				 XCB_CONFIG_WINDOW_Y
-#define WINDOW_W				 XCB_CONFIG_WINDOW_WIDTH
-#define WINDOW_H				 XCB_CONFIG_WINDOW_HEIGHT
-#define S_NOTIFY				 XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY
-#define S_REDIRECT				 XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT
+#define WINDOW_X		(XCB_CONFIG_WINDOW_X)
+#define WINDOW_Y		(XCB_CONFIG_WINDOW_Y)
+#define WINDOW_W		(XCB_CONFIG_WINDOW_WIDTH)
+#define WINDOW_H		(XCB_CONFIG_WINDOW_HEIGHT)
+#define S_NOTIFY		(XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY)
+#define S_REDIRECT		(XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT)
 
-#define XCB_MOVE_RESIZE			 (WINDOW_X | WINDOW_Y | WINDOW_W | WINDOW_H)
-#define XCB_MOVE				 (WINDOW_X | WINDOW_Y)
-#define XCB_RESIZE				 (WINDOW_W | WINDOW_H)
-#define SUBSTRUCTURE_REDIRECTION (S_NOTIFY | S_REDIRECT)
+#define MOVE_RESIZE		(WINDOW_X | WINDOW_Y | WINDOW_W | WINDOW_H)
+#define MOVE			(WINDOW_X | WINDOW_Y)
+#define RESIZE			(WINDOW_W | WINDOW_H)
+#define SUBSTRUCTURE	(S_NOTIFY | S_REDIRECT)
+
+#define PROPERTY_CHANGE (XCB_EVENT_MASK_PROPERTY_CHANGE)
+#define FOCUS_CHANGE	(XCB_EVENT_MASK_FOCUS_CHANGE)
+#define ENTER_WINDOW	(XCB_EVENT_MASK_ENTER_WINDOW)
+#define LEAVE_WINDOW	(XCB_EVENT_MASK_LEAVE_WINDOW)
+#define BUTTON_PRESS	(XCB_EVENT_MASK_BUTTON_PRESS)
+#define BUTTON_RELEASE	(XCB_EVENT_MASK_BUTTON_RELEASE)
+#define POINTER_MOTION	(XCB_EVENT_MASK_POINTER_MOTION)
+
+#define ALT_MASK		(XCB_MOD_MASK_1)
+#define SUPER_MASK		(XCB_MOD_MASK_4)
+#define SHIFT_MASK		(XCB_MOD_MASK_SHIFT)
+#define CTRL_MASK		(XCB_MOD_MASK_CONTROL)
+#define CLICK_TO_FOCUS	(XCB_BUTTON_INDEX_1)
 
 #define CLIENT_EVENT_MASK                                                      \
-	(XCB_EVENT_MASK_PROPERTY_CHANGE | XCB_EVENT_MASK_FOCUS_CHANGE |            \
-	 XCB_EVENT_MASK_ENTER_WINDOW | XCB_EVENT_MASK_LEAVE_WINDOW)
+	(PROPERTY_CHANGE | FOCUS_CHANGE | ENTER_WINDOW | LEAVE_WINDOW)
 
 #define ROOT_EVENT_MASK                                                        \
-	(SUBSTRUCTURE_REDIRECTION | XCB_EVENT_MASK_BUTTON_PRESS |                  \
-	 XCB_EVENT_MASK_FOCUS_CHANGE | XCB_EVENT_MASK_ENTER_WINDOW)
+	(SUBSTRUCTURE | BUTTON_PRESS | FOCUS_CHANGE | POINTER_MOTION | ENTER_WINDOW)
 
 #define NUMBER_OF_DESKTOPS 7
 #define WM_NAME			   "zwm"
 #define WM_CLASS_NAME	   "null"
 #define WM_INSTANCE_NAME   "null"
-#define ALT_MASK		   XCB_MOD_MASK_1
-#define SUPER_MASK		   XCB_MOD_MASK_4
-#define SHIFT_MASK		   XCB_MOD_MASK_SHIFT
-#define CTRL_MASK		   XCB_MOD_MASK_CONTROL
-#define CLICK_TO_FOCUS	   XCB_BUTTON_INDEX_1
 
 wm_t				 *wm			 = NULL;
 config_t			  conf			 = {0};
@@ -98,53 +105,49 @@ xcb_cursor_t		  cursors[CURSOR_MAX];
 // clang-format off
 // X11/keysymdef.h
 static const _key__t keys_[] = {
-	{SUPER_MASK,              XK_w,      close_or_kill_wrapper,      NULL                      },
-	{SUPER_MASK,              XK_Return,
-    exec_process,             &((arg_t){.argc = 1, .cmd = (char *[]){("alacritty")}})          },
-	{SUPER_MASK,              XK_space,
-    exec_process,             &((arg_t){.argc = 1, .cmd = (char *[]){("dmenu_run")}})          },
-	{SUPER_MASK,              XK_p,
-    exec_process,             &((arg_t){.argc = 3, .cmd = (char *[]){"rofi", "-show", "drun"}})},
-	{SUPER_MASK,              XK_1,      switch_desktop_wrapper,    &((arg_t){.idx = 0})       },
-	{SUPER_MASK,              XK_2,      switch_desktop_wrapper,    &((arg_t){.idx = 1})       },
-	{SUPER_MASK,              XK_3,      switch_desktop_wrapper,    &((arg_t){.idx = 2})       },
-	{SUPER_MASK,              XK_4,      switch_desktop_wrapper,    &((arg_t){.idx = 3})       },
-	{SUPER_MASK,              XK_5,      switch_desktop_wrapper,    &((arg_t){.idx = 4})       },
-	{SUPER_MASK,              XK_6,      switch_desktop_wrapper,    &((arg_t){.idx = 5})       },
-	{SUPER_MASK,              XK_7,      switch_desktop_wrapper,    &((arg_t){.idx = 6})       },
-	{SUPER_MASK,              XK_Left,   cycle_win_wrapper,         &((arg_t){.d = LEFT})      },
-	{SUPER_MASK,              XK_Right,  cycle_win_wrapper,         &((arg_t){.d = RIGHT})     },
-	{SUPER_MASK,              XK_Up,     cycle_win_wrapper,         &((arg_t){.d = UP})        },
-	{SUPER_MASK,              XK_Down,   cycle_win_wrapper,         &((arg_t){.d = DOWN})      },
-	{SUPER_MASK,              XK_l,      horizontal_resize_wrapper, &((arg_t){.r = GROW})      },
-	{SUPER_MASK,              XK_h,      horizontal_resize_wrapper, &((arg_t){.r = SHRINK})    },
-	{SUPER_MASK,              XK_f,      set_fullscreen_wrapper,    NULL                       },
-	{SUPER_MASK,              XK_s,      swap_node_wrapper,         NULL                       },
-	{SUPER_MASK | SHIFT_MASK, XK_1,      transfer_node_wrapper,     &((arg_t){.idx = 0})       },
-	{SUPER_MASK | SHIFT_MASK, XK_2,      transfer_node_wrapper,     &((arg_t){.idx = 1})       },
-	{SUPER_MASK | SHIFT_MASK, XK_3,      transfer_node_wrapper,     &((arg_t){.idx = 2})       },
-	{SUPER_MASK | SHIFT_MASK, XK_4,      transfer_node_wrapper,     &((arg_t){.idx = 3})       },
-	{SUPER_MASK | SHIFT_MASK, XK_5,      transfer_node_wrapper,     &((arg_t){.idx = 4})       },
-	{SUPER_MASK | SHIFT_MASK, XK_6,      transfer_node_wrapper,     &((arg_t){.idx = 5})       },
-	{SUPER_MASK | SHIFT_MASK, XK_7,      transfer_node_wrapper,     &((arg_t){.idx = 6})       },
-	{SUPER_MASK | SHIFT_MASK, XK_m,      layout_handler,            &((arg_t){.t = MASTER})    },
-    {SUPER_MASK | SHIFT_MASK, XK_d,      layout_handler,            &((arg_t){.t = DEFAULT})   },
-    {SUPER_MASK | SHIFT_MASK, XK_s,      layout_handler,            &((arg_t){.t = STACK})     },
-	{SUPER_MASK | SHIFT_MASK, XK_k,      traverse_stack_wrapper,    &((arg_t){.d = UP})        },
-    {SUPER_MASK | SHIFT_MASK, XK_j,      traverse_stack_wrapper,    &((arg_t){.d = DOWN})      },
-    {SUPER_MASK | SHIFT_MASK, XK_f,      flip_node_wrapper,   		NULL            		   },
-    {SUPER_MASK | SHIFT_MASK, XK_r,      reload_config_wrapper,   	NULL            		   },
-	{SUPER_MASK | SHIFT_MASK, XK_Left, 	 cycle_desktop_wrapper, 	&((arg_t){.d = LEFT}) 	   },
-	{SUPER_MASK | SHIFT_MASK, XK_Right,  cycle_desktop_wrapper, 	&((arg_t){.d = RIGHT}) 	   },
-	{SHIFT_MASK,              XK_Left,   shift_floating_window,     &((arg_t){.d = LEFT})      },
-	{SHIFT_MASK,              XK_Right,  shift_floating_window,     &((arg_t){.d = RIGHT})     },
-	{SHIFT_MASK,              XK_Up,     shift_floating_window,     &((arg_t){.d = UP})        },
-	{SHIFT_MASK,              XK_Down,   shift_floating_window,     &((arg_t){.d = DOWN})      },
-    {SUPER_MASK,              XK_i,      gap_handler,               &((arg_t){.r = GROW})      },
-    {SUPER_MASK,              XK_d,      gap_handler,               &((arg_t){.r = SHRINK})    },
-	{SHIFT_MASK,              XK_f,   	 change_state,              &((arg_t){.s = FLOATING})  },
-	{SHIFT_MASK,              XK_t,   	 change_state,              &((arg_t){.s = TILED})  },
-
+    DEFINE_KEY(SUPER_MASK,          XK_w,       close_or_kill_wrapper,     NULL),
+    DEFINE_KEY(SUPER_MASK,          XK_Return,  exec_process,              &((arg_t){.argc = 1, .cmd = (char *[]){"alacritty"}})),
+    DEFINE_KEY(SUPER_MASK,          XK_space,   exec_process,              &((arg_t){.argc = 1, .cmd = (char *[]){"dmenu_run"}})),
+    DEFINE_KEY(SUPER_MASK,          XK_p,       exec_process,              &((arg_t){.argc = 3, .cmd = (char *[]){"rofi", "-show", "drun"}})),
+    DEFINE_KEY(SUPER_MASK,          XK_1,       switch_desktop_wrapper,    &((arg_t){.idx = 0})),
+    DEFINE_KEY(SUPER_MASK,          XK_2,       switch_desktop_wrapper,    &((arg_t){.idx = 1})),
+    DEFINE_KEY(SUPER_MASK,          XK_3,       switch_desktop_wrapper,    &((arg_t){.idx = 2})),
+    DEFINE_KEY(SUPER_MASK,          XK_4,       switch_desktop_wrapper,    &((arg_t){.idx = 3})),
+    DEFINE_KEY(SUPER_MASK,          XK_5,       switch_desktop_wrapper,    &((arg_t){.idx = 4})),
+    DEFINE_KEY(SUPER_MASK,          XK_6,       switch_desktop_wrapper,    &((arg_t){.idx = 5})),
+    DEFINE_KEY(SUPER_MASK,          XK_7,       switch_desktop_wrapper,    &((arg_t){.idx = 6})),
+    DEFINE_KEY(SUPER_MASK,          XK_Left,    cycle_win_wrapper,         &((arg_t){.d = LEFT})),
+    DEFINE_KEY(SUPER_MASK,          XK_Right,   cycle_win_wrapper,         &((arg_t){.d = RIGHT})),
+    DEFINE_KEY(SUPER_MASK,          XK_Up,      cycle_win_wrapper,         &((arg_t){.d = UP})),
+    DEFINE_KEY(SUPER_MASK,          XK_Down,    cycle_win_wrapper,         &((arg_t){.d = DOWN})),
+    DEFINE_KEY(SUPER_MASK,          XK_l,       horizontal_resize_wrapper, &((arg_t){.r = GROW})),
+    DEFINE_KEY(SUPER_MASK,          XK_h,       horizontal_resize_wrapper, &((arg_t){.r = SHRINK})),
+    DEFINE_KEY(SUPER_MASK,          XK_f,       set_fullscreen_wrapper,    NULL),
+    DEFINE_KEY(SUPER_MASK,          XK_s,       swap_node_wrapper,         NULL),
+    DEFINE_KEY(SUPER_MASK | SHIFT_MASK, XK_1,    transfer_node_wrapper,     &((arg_t){.idx = 0})),
+    DEFINE_KEY(SUPER_MASK | SHIFT_MASK, XK_2,    transfer_node_wrapper,     &((arg_t){.idx = 1})),
+    DEFINE_KEY(SUPER_MASK | SHIFT_MASK, XK_3,    transfer_node_wrapper,     &((arg_t){.idx = 2})),
+    DEFINE_KEY(SUPER_MASK | SHIFT_MASK, XK_4,    transfer_node_wrapper,     &((arg_t){.idx = 3})),
+    DEFINE_KEY(SUPER_MASK | SHIFT_MASK, XK_5,    transfer_node_wrapper,     &((arg_t){.idx = 4})),
+    DEFINE_KEY(SUPER_MASK | SHIFT_MASK, XK_6,    transfer_node_wrapper,     &((arg_t){.idx = 5})),
+    DEFINE_KEY(SUPER_MASK | SHIFT_MASK, XK_7,    transfer_node_wrapper,     &((arg_t){.idx = 6})),
+    DEFINE_KEY(SUPER_MASK | SHIFT_MASK, XK_m,    layout_handler,            &((arg_t){.t = MASTER})),
+    DEFINE_KEY(SUPER_MASK | SHIFT_MASK, XK_d,    layout_handler,            &((arg_t){.t = DEFAULT})),
+    DEFINE_KEY(SUPER_MASK | SHIFT_MASK, XK_s,    layout_handler,            &((arg_t){.t = STACK})),
+    DEFINE_KEY(SUPER_MASK | SHIFT_MASK, XK_k,    traverse_stack_wrapper,    &((arg_t){.d = UP})),
+    DEFINE_KEY(SUPER_MASK | SHIFT_MASK, XK_j,    traverse_stack_wrapper,    &((arg_t){.d = DOWN})),
+    DEFINE_KEY(SUPER_MASK | SHIFT_MASK, XK_f,    flip_node_wrapper,         NULL),
+    DEFINE_KEY(SUPER_MASK | SHIFT_MASK, XK_r,    reload_config_wrapper,     NULL),
+    DEFINE_KEY(SUPER_MASK | SHIFT_MASK, XK_Left, cycle_desktop_wrapper,     &((arg_t){.d = LEFT})),
+    DEFINE_KEY(SUPER_MASK | SHIFT_MASK, XK_Right,cycle_desktop_wrapper,     &((arg_t){.d = RIGHT})),
+    DEFINE_KEY(SHIFT_MASK,          XK_Left,    shift_floating_window,     &((arg_t){.d = LEFT})),
+    DEFINE_KEY(SHIFT_MASK,          XK_Right,   shift_floating_window,     &((arg_t){.d = RIGHT})),
+    DEFINE_KEY(SHIFT_MASK,          XK_Up,      shift_floating_window,     &((arg_t){.d = UP})),
+    DEFINE_KEY(SHIFT_MASK,          XK_Down,    shift_floating_window,     &((arg_t){.d = DOWN})),
+    DEFINE_KEY(SUPER_MASK,          XK_i,       gap_handler,               &((arg_t){.r = GROW})),
+    DEFINE_KEY(SUPER_MASK,          XK_d,       gap_handler,               &((arg_t){.r = SHRINK})),
+    DEFINE_KEY(SHIFT_MASK,          XK_f,       change_state,              &((arg_t){.s = FLOATING})),
+    DEFINE_KEY(SHIFT_MASK,          XK_t,       change_state,              &((arg_t){.s = TILED})),
 };
 
 static const uint32_t buttons_[] = {
@@ -179,6 +182,41 @@ static int hide_window(xcb_window_t win);
 static xcb_get_geometry_reply_t *get_geometry(xcb_window_t win, xcb_conn_t *conn);
 static bool setup_desktops(void);
 static node_t *get_foucsed_desktop_tree(void);
+static int handle_map_request(const xcb_generic_event_t *);
+static int handle_unmap_notify(const xcb_generic_event_t *);
+static int handle_destroy_notify(const xcb_generic_event_t *);
+static int handle_client_message(const xcb_generic_event_t *);
+static int handle_configure_request(const xcb_generic_event_t *);
+static int handle_enter_notify(const xcb_generic_event_t *);
+static int handle_button_press_event(const xcb_generic_event_t *);
+static int handle_key_press(const xcb_generic_event_t *);
+static int handle_mapping_notify(const xcb_generic_event_t *);
+static int handle_leave_notify(const xcb_generic_event_t *);
+static int handle_motion_notify(const xcb_generic_event_t *);
+
+static const event_handler_entry_t event_handlers[] = {
+	/* core window management events */
+    DEFINE_MAPPING(XCB_MAP_REQUEST, handle_map_request),
+    DEFINE_MAPPING(XCB_UNMAP_NOTIFY, handle_unmap_notify),
+    DEFINE_MAPPING(XCB_DESTROY_NOTIFY, handle_destroy_notify),
+    /* communication and configuration events */
+    DEFINE_MAPPING(XCB_CLIENT_MESSAGE, handle_client_message),
+    DEFINE_MAPPING(XCB_CONFIGURE_REQUEST, handle_configure_request),
+    /* input and interaction events */
+    DEFINE_MAPPING(XCB_ENTER_NOTIFY, handle_enter_notify),
+    DEFINE_MAPPING(XCB_BUTTON_PRESS, handle_button_press_event),
+    DEFINE_MAPPING(XCB_KEY_PRESS, handle_key_press),
+    DEFINE_MAPPING(XCB_MAPPING_NOTIFY, handle_mapping_notify),
+    DEFINE_MAPPING(XCB_MOTION_NOTIFY, handle_motion_notify),
+   	/* will be implemented if needed */
+    /* DEFINE_MAPPING(XCB_LEAVE_NOTIFY, handle_leave_notify), */
+    /* DEFINE_MAPPING(XCB_BUTTON_RELEASE, handle_button_release), */
+    /* DEFINE_MAPPING(XCB_KEY_RELEASE, handle_key_release), */
+    /* DEFINE_MAPPING(XCB_FOCUS_IN, handle_focus_in), */
+    /* DEFINE_MAPPING(XCB_FOCUS_OUT, handle_focus_out), */
+    /* DEFINE_MAPPING(XCB_CONFIGURE_NOTIFY, handle_configure_notify), */
+    /* DEFINE_MAPPING(XCB_PROPERTY_NOTIFY, handle_property_notify), */
+};
 // clang-format on
 
 static void
@@ -225,7 +263,7 @@ set_cursor(int cursor_id)
 	xcb_flush(wm->connection);
 }
 
-// caller must free
+/* caller must free */
 char *
 win_name(xcb_window_t win)
 {
@@ -233,20 +271,18 @@ win_name(xcb_window_t win)
 	xcb_get_property_cookie_t cn = xcb_icccm_get_wm_name(wm->connection, win);
 	const uint8_t			  wr =
 		xcb_icccm_get_wm_name_reply(wm->connection, cn, &t_reply, NULL);
+	if (wr != 1)
+		return NULL;
 
-	if (wr == 1) {
-		char *str = (char *)malloc(t_reply.name_len + 1);
-		if (str == NULL)
-			return NULL;
+	char *str = (char *)malloc(t_reply.name_len + 1);
+	if (str == NULL)
+		return NULL;
 
-		strncpy(str, (char *)t_reply.name, t_reply.name_len);
-		str[t_reply.name_len] = '\0';
+	strncpy(str, (char *)t_reply.name, t_reply.name_len);
+	str[t_reply.name_len] = '\0';
+	xcb_icccm_get_text_property_reply_wipe(&t_reply);
 
-		xcb_icccm_get_text_property_reply_wipe(&t_reply);
-		return str;
-	}
-
-	return NULL;
+	return str;
 }
 
 int
@@ -259,9 +295,9 @@ layout_handler(arg_t *arg)
 	}
 
 	desktop_t *d = curr_monitor->desktops[i];
-
 	if (arg->t == STACK && d->n_count < 2)
 		return 0;
+
 	apply_layout(d, arg->t);
 	return render_tree(d->tree);
 }
@@ -272,9 +308,11 @@ get_foucsed_desktop_tree(void)
 	int idx = get_focused_desktop_idx();
 	if (idx == -1)
 		return NULL;
+
 	node_t *root = curr_monitor->desktops[idx]->tree;
 	if (root == NULL)
 		return NULL;
+
 	return root;
 }
 
@@ -298,6 +336,7 @@ render_trees(void)
 	}
 }
 
+/* changes the state of a window between tiled and floating. */
 int
 change_state(arg_t *arg)
 {
@@ -310,7 +349,6 @@ change_state(arg_t *arg)
 		return -1;
 
 	node_t *n = find_node_by_window_id(root, w);
-	/* node_t *n = get_focused_node(root); */
 
 	if (n == NULL)
 		return -1;
@@ -321,7 +359,6 @@ change_state(arg_t *arg)
 	state_t state  = arg->s;
 	node_t *parent = n->parent;
 	if (state == TILED) {
-		// n->floating_rectangle = n->rectangle;
 		if (IS_TILED(n->client))
 			return 0;
 		n->client->state = TILED;
@@ -524,7 +561,6 @@ ewmh_update_desktop_names(void)
 	memset(names, 0, sizeof(names));
 
 	for (int n = 0; n < prim_monitor->n_of_desktops; n++) {
-		// for (int i = 0; i < wm->monitors[n]->n_of_desktops; i++) {
 		desktop_t *d = prim_monitor->desktops[n];
 		for (int j = 0; d->name[j] != '\0' && (offset + j) < sizeof(names);
 			 j++) {
@@ -534,7 +570,6 @@ ewmh_update_desktop_names(void)
 		if (offset < sizeof(names)) {
 			names[offset++] = '\0';
 		}
-		// }
 	}
 
 	names_len			= offset - 1;
@@ -633,7 +668,7 @@ release_grab:
 	xcb_ungrab_server(con);
 }
 
-// Stack win1 above win2
+/* stack win1 above win2 */
 void
 window_above(xcb_window_t win1, xcb_window_t win2)
 {
@@ -654,7 +689,7 @@ window_above(xcb_window_t win1, xcb_window_t win2)
 	}
 }
 
-// Stack win1 below win2
+/* stack win1 below win2 */
 void
 window_below(xcb_window_t win1, xcb_window_t win2)
 {
@@ -725,9 +760,8 @@ swap_node_wrapper()
 	if (w == wm->root_window) {
 		return 0;
 	}
-	/* node_t *n = find_node_by_window_id(root, w); */
-	node_t *n = get_focused_node(root);
 
+	node_t *n = get_focused_node(root);
 	if (n == NULL)
 		return -1;
 
@@ -744,12 +778,6 @@ shift_floating_window(arg_t *arg)
 	if (root == NULL)
 		return -1;
 
-	// xcb_window_t w =
-	// 	get_window_under_cursor(wm->connection, wm->root_window);
-	// if (w == wm->root_window)
-	// 	return 0;
-
-	// node_t *n = find_node_by_window_id(root, w);
 	node_t *n = get_focused_node(root);
 	if (n == NULL)
 		return -1;
@@ -812,16 +840,16 @@ set_fullscreen_wrapper()
 		return -1;
 
 	xcb_window_t w = get_window_under_cursor(wm->connection, wm->root_window);
-
 	if (w == wm->root_window) {
 		return 0;
 	}
+
 	node_t *n = find_node_by_window_id(root, w);
-	/* node_t *n = get_focused_node(root); */
 	if (n == NULL) {
 		_LOG_(ERROR, "cannot find focused node");
 		return -1;
 	}
+
 	n->client->state == FULLSCREEN ? set_fullscreen(n, false)
 								   : set_fullscreen(n, true);
 	return 0;
@@ -834,7 +862,6 @@ set_fullscreen(node_t *n, bool flag)
 		return -1;
 
 	rectangle_t r = {0};
-
 	if (flag) {
 		long data[]		 = {wm->ewmh->_NET_WM_STATE_FULLSCREEN};
 		r.x				 = curr_monitor->rectangle.x;
@@ -888,15 +915,6 @@ set_fullscreen(node_t *n, bool flag)
 						   true) != 0) {
 		return -1;
 	}
-	// xcb_void_cookie_t c =
-	// 	xcb_delete_property_checked(wm->connection,
-	// 								n->client->window,
-	// 								wm->ewmh->_NET_WM_STATE_FULLSCREEN);
-	// xcb_generic_error_t *err = xcb_request_check(wm->connection,
-	// c); if (err) { 	_LOG_(ERROR, 				"Error removing
-	// window property: %d", 				err->error_code);
-	// free(err); 	return -1;
-	// }
 out:
 	xcb_flush(wm->connection);
 	return 0;
@@ -923,6 +941,7 @@ change_colors(node_t *root)
 	return 0;
 }
 
+/* TODO: rewrite this shit */
 static void
 apply_monitor_layout_changes(monitor_t *m)
 {
@@ -1015,14 +1034,14 @@ apply_monitor_layout_changes(monitor_t *m)
 static void
 arrange_trees(void)
 {
-	monitor_t *current_monitor = head_monitor;
-	while (current_monitor) {
-		apply_monitor_layout_changes(current_monitor);
-		current_monitor = current_monitor->next;
+	monitor_t *curr = head_monitor;
+	while (curr) {
+		apply_monitor_layout_changes(curr);
+		curr = curr->next;
 	}
 }
 
-// TODO: rewrite this
+/* TODO: rewrite this ugly shit */
 int
 reload_config_wrapper()
 {
@@ -1187,10 +1206,13 @@ out:
 int
 gap_handler(arg_t *arg)
 {
-	const int pxl			   = 5;
-	conf.window_gap			   = (arg->r == GROW) ? conf.window_gap + pxl
-								 : (conf.window_gap - pxl <= 0) ? 0
-																: conf.window_gap - pxl;
+	const int pxl = 5;
+	if (arg->r == GROW) {
+		conf.window_gap += pxl;
+	} else {
+		conf.window_gap =
+			(conf.window_gap - pxl <= 0) ? 0 : conf.window_gap - pxl;
+	}
 
 	monitor_t *current_monitor = head_monitor;
 	while (current_monitor) {
@@ -1216,8 +1238,6 @@ flip_node_wrapper()
 	if (w == wm->root_window)
 		return 0;
 
-	/* node_t *node = find_node_by_window_id( */
-	/* 	curr_monitor->desktops[get_focused_desktop_idx()]->tree, w); */
 	node_t *tree = get_foucsed_desktop_tree();
 	if (!tree)
 		return -1;
@@ -1272,7 +1292,6 @@ traverse_stack_wrapper(arg_t *arg)
 	node_t *root = get_foucsed_desktop_tree();
 	if (!root)
 		return -1;
-	/* node_t *node = find_node_by_window_id(root, w); */
 
 	node_t *node = get_focused_node(root);
 	node_t *n	 = d == UP ? next_node(node) : prev_node(node);
@@ -1337,9 +1356,9 @@ ewmh_update_client_list(void)
 		_LOG_(ERROR, "unable to get clients size");
 		return;
 	}
-	// TODO handle stacking client list --
-	// xcb_ewmh_set_client_list_stacking(...)
-	//  xcb_window_t active_clients[size + 1];
+	/* TODO handle stacking client list --
+	 * xcb_ewmh_set_client_list_stacking(...)
+	 * xcb_window_t active_clients[size+1]; */
 	xcb_window_t *active_clients =
 		(xcb_window_t *)malloc((size + 1) * sizeof(xcb_window_t));
 	if (active_clients == NULL) {
@@ -1515,7 +1534,8 @@ log_monitors(void)
 	monitor_t *curr = head_monitor;
 	while (curr) {
 		_LOG_(INFO,
-			  "found monitor %s:%d, rectangle {.x = %d, .y = %d, .w = %d, .h = "
+			  "found monitor %s:%d, rectangle {.x = %d, .y = %d, .w = %d, "
+			  ".h = "
 			  "%d}",
 			  curr->name,
 			  curr->randr_id,
@@ -1557,7 +1577,7 @@ init_wm(void)
 	const uint32_t	  mask	   = XCB_CW_EVENT_MASK;
 	const uint32_t	  values[] = {ROOT_EVENT_MASK};
 
-	// register events
+	/* register events */
 	xcb_void_cookie_t cookie   = xcb_change_window_attributes_checked(
 		  wm->connection, wm->root_window, mask, values);
 	xcb_generic_error_t *err = xcb_request_check(wm->connection, cookie);
@@ -1573,22 +1593,18 @@ init_wm(void)
 		return NULL;
 	}
 
-	meta_window = xcb_generate_id(wm->connection);
-	xcb_create_window(wm->connection,
-					  XCB_COPY_FROM_PARENT,
-					  meta_window,
-					  wm->root_window,
-					  -1,
-					  -1,
-					  1,
-					  1,
-					  0,
-					  XCB_WINDOW_CLASS_INPUT_ONLY,
-					  XCB_COPY_FROM_PARENT,
-					  XCB_NONE,
-					  NULL);
-	xcb_icccm_set_wm_class(
-		wm->connection, meta_window, sizeof(WM_NAME), WM_NAME);
+	meta_window				 = xcb_generate_id(wm->connection);
+	xcb_connection_t *dpy	 = wm->connection;
+	uint8_t			  depth	 = XCB_COPY_FROM_PARENT;
+	xcb_window_t	  mw	 = meta_window;
+	xcb_window_t	  rw	 = wm->root_window;
+	uint32_t		  m		 = XCB_NONE;
+	xcb_visualid_t	  visual = XCB_COPY_FROM_PARENT;
+	uint16_t class			 = XCB_WINDOW_CLASS_INPUT_ONLY;
+
+	xcb_create_window(
+		dpy, depth, mw, rw, -1, -1, 1, 1, 0, class, visual, m, NULL);
+	xcb_icccm_set_wm_class(dpy, mw, sizeof(WM_NAME), WM_NAME);
 	return wm;
 }
 
@@ -1657,8 +1673,6 @@ get_connected_monitor_count_xinerama()
 		xcb_xinerama_query_screens(wm->connection);
 	xcb_xinerama_query_screens_reply_t *xquery =
 		xcb_xinerama_query_screens_reply(wm->connection, c, NULL);
-	// xcb_xinerama_screen_info_t *xscreen =
-	// 	xcb_xinerama_query_screens_screen_info(xquery);
 	int len = xcb_xinerama_query_screens_screen_info_length(xquery);
 	free(xquery);
 	return len;
@@ -1750,12 +1764,6 @@ setup_monitors_via_xrandr()
 			_FREE_(info);
 			continue;
 		}
-		// monitor_t *mm = get_monitor_by_randr_id(outputs[i]);
-		// if (mm) {
-		// 	_LOG_(INFO, "monitor was found... skipping this output");
-		// 	_FREE_(info);
-		// 	continue;
-		// }
 		xcb_randr_get_crtc_info_cookie_t ic;
 		xcb_randr_get_crtc_info_reply_t *crtc;
 		ic = xcb_randr_get_crtc_info(conn, info->crtc, time);
@@ -1824,7 +1832,6 @@ setup_monitors_via_xinerama()
 		return false;
 	}
 	int n = xcb_xinerama_query_screens_screen_info_length(query_screens_r);
-	// int monitor_count = 0;
 	for (int i = 0; i < n; i++) {
 		xcb_xinerama_screen_info_t info = xinerama_screen_i[i];
 		rectangle_t				   r =
@@ -1873,25 +1880,25 @@ free_monitors(void)
 static void
 ewmh_update_desktop_viewport(void)
 {
-	uint32_t   desktops_count  = 0;
-	monitor_t *current_monitor = head_monitor;
-	while (current_monitor) {
-		desktops_count += current_monitor->n_of_desktops;
-		current_monitor = current_monitor->next;
+	uint32_t   count = 0;
+	monitor_t *curr	 = head_monitor;
+	while (curr) {
+		count += curr->n_of_desktops;
+		curr = curr->next;
 	}
-	if (desktops_count == 0) {
+	if (count == 0) {
 		xcb_ewmh_set_desktop_viewport(wm->ewmh, wm->screen_nbr, 0, NULL);
 		return;
 	}
-	xcb_ewmh_coordinates_t coords[desktops_count];
+	xcb_ewmh_coordinates_t coords[count];
 	uint16_t			   desktop = 0;
-	current_monitor				   = head_monitor;
-	while (current_monitor) {
-		for (int j = 0; j < current_monitor->n_of_desktops; j++) {
-			coords[desktop++] = (xcb_ewmh_coordinates_t){
-				current_monitor->rectangle.x, current_monitor->rectangle.y};
+	curr						   = head_monitor;
+	while (curr) {
+		for (int j = 0; j < curr->n_of_desktops; j++) {
+			coords[desktop++] =
+				(xcb_ewmh_coordinates_t){curr->rectangle.x, curr->rectangle.y};
 		}
-		current_monitor = current_monitor->next;
+		curr = curr->next;
 	}
 	xcb_ewmh_set_desktop_viewport(wm->ewmh, wm->screen_nbr, desktop, coords);
 }
@@ -1976,46 +1983,45 @@ setup_monitors(void)
 		return false;
 	}
 
-	// set monitors roots
-	// for (int i = 0; i < wm->n_of_monitors; i++) {
-	// 	if (wm->monitors[i] ) {
-	// 		uint32_t values[]	  = {XCB_EVENT_MASK_ENTER_WINDOW};
-	// 		wm->monitors[i]->root = xcb_generate_id(wm->connection);
-	// 		xcb_create_window(wm->connection,
-	// 						  XCB_COPY_FROM_PARENT,
-	// 						  wm->monitors[i]->root,
-	// 						  wm->root_window,
-	// 						  wm->monitors[i]->rectangle.x,
-	// 						  wm->monitors[i]->rectangle.y,
-	// 						  wm->monitors[i]->rectangle.width,
-	// 						  wm->monitors[i]->rectangle.height,
-	// 						  0,
-	// 						  XCB_WINDOW_CLASS_INPUT_ONLY,
-	// 						  XCB_COPY_FROM_PARENT,
-	// 						  XCB_CW_EVENT_MASK,
-	// 						  values);
-	// 		const uint32_t mask = XCB_CW_EVENT_MASK;
-	// 		xcb_change_window_attributes(
-	// 			wm->connection, wm->monitors[i]->root, mask, values);
-	// 		_LOG_(INFO,
-	// 			  "succseffuly created root %d for monitor %s",
-	// 			  wm->monitors[i]->root,
-	// 			  wm->monitors[i]->name);
-	// 		// show_window(wm->monitors[i]->root);
-	// 		lower_window(wm->monitors[i]->root);
-	// 		xcb_icccm_set_wm_class(wm->connection,
-	// 							   wm->monitors[i]->root,
-	// 							   sizeof(ROOT_WINDOW),
-	// 							   ROOT_WINDOW);
-	// 		xcb_icccm_set_wm_name(wm->connection,
-	// 							  wm->monitors[i]->root,
-	// 							  XCB_ATOM_STRING,
-	// 							  8,
-	// 							  strlen(wm->monitors[i]->name),
-	// 							  wm->monitors[i]->name);
-	// 	}
-	// }
-	// primary monitor
+	/* set monitors roots */
+#if 0
+	monitor_t *curr = head_monitor;
+	while (curr) {
+		uint32_t values[] = {XCB_EVENT_MASK_ENTER_WINDOW};
+		curr->root		  = xcb_generate_id(wm->connection);
+		xcb_create_window(wm->connection,
+						  XCB_COPY_FROM_PARENT,
+						  curr->root,
+						  wm->root_window,
+						  curr->rectangle.x,
+						  curr->rectangle.y,
+						  curr->rectangle.width,
+						  curr->rectangle.height,
+						  0,
+						  XCB_WINDOW_CLASS_INPUT_ONLY,
+						  XCB_COPY_FROM_PARENT,
+						  XCB_CW_EVENT_MASK,
+						  values);
+		const uint32_t mask = XCB_CW_EVENT_MASK;
+		xcb_change_window_attributes(wm->connection, curr->root, mask, values);
+		_LOG_(INFO,
+			  "succseffuly created root %d for monitor %s",
+			  curr->root,
+			  curr->name);
+		// show_window(curr->root);
+		lower_window(curr->root);
+		xcb_icccm_set_wm_class(
+			wm->connection, curr->root, sizeof(ROOT_WINDOW), ROOT_WINDOW);
+		xcb_icccm_set_wm_name(wm->connection,
+							  curr->root,
+							  XCB_ATOM_STRING,
+							  8,
+							  strlen(curr->name),
+							  curr->name);
+	}
+#endif
+
+	/* primary monitor */
 	xcb_randr_get_output_primary_cookie_t ccc =
 		xcb_randr_get_output_primary(wm->connection, wm->root_window);
 	xcb_randr_get_output_primary_reply_t *primary_output_reply =
@@ -2166,8 +2172,8 @@ update_monitors(uint32_t *changes)
 		if (!info)
 			continue;
 		if (info->connection == XCB_RANDR_CONNECTION_DISCONNECTED) {
-			/* this output might have been connnected before, if so, add it to
-			 * the list so we can remove it later */
+			/* this output might have been connnected before, if so, add it
+			 * to the list so we can remove it later */
 			monitor_t *exist = get_monitor_by_randr_id(outputs[i]);
 			if (!exist) {
 				free(info);
@@ -2214,11 +2220,11 @@ update_monitors(uint32_t *changes)
 	if (dl) {
 		/* windows from disconnected monitors are supposed to be moved
 		 * to any other available monitor. BUT, this require some
-		 * extra work to merge trees/desktops without triggering other inner
-		 * calls that may cause craches */
+		 * extra work to merge trees/desktops without triggering other
+		 * inner calls that may cause craches */
 
-		/* for now, a disconneced monitor is freed entirely, this includes its
-		 * desktops and trees, things will be lost as a result */
+		/* for now, a disconneced monitor is freed entirely, this includes
+		 * its desktops and trees, things will be lost as a result */
 		while (dl) {
 			monitor_t *to_remove = dl;
 			dl					 = dl->next;
@@ -2246,7 +2252,7 @@ handle_monitor_changes(void)
 	if (using_xinerama) {
 		return;
 	}
-	uint32_t m_change = _NONE;
+	uint32_t m_change = 0 | _NONE; /* set the none flag */
 	update_monitors(&m_change);
 	if (m_change & _NONE) {
 		_LOG_(INFO, "no monitor changes was found");
@@ -2269,17 +2275,33 @@ handle_monitor_changes(void)
 	// TODO: update ewmh
 }
 
-monitor_t *
+static monitor_t *
+get_monitor_within_coordinate(int16_t x, int16_t y)
+{
+	monitor_t *curr = head_monitor;
+	while (curr) {
+		if (x >= curr->rectangle.x &&
+			x < (curr->rectangle.x + curr->rectangle.width) &&
+			y >= curr->rectangle.y &&
+			y < (curr->rectangle.y + curr->rectangle.height)) {
+			return curr;
+		}
+		curr = curr->next;
+	}
+	return NULL;
+}
+
+static monitor_t *
 get_monitor_from_desktop(desktop_t *desktop)
 {
-	monitor_t *current_monitor = head_monitor;
-	while (current_monitor) {
-		for (int j = 0; j < current_monitor->n_of_desktops; j++) {
-			if (current_monitor->desktops[j] == desktop) {
-				return current_monitor;
+	monitor_t *curr = head_monitor;
+	while (curr) {
+		for (int j = 0; j < curr->n_of_desktops; j++) {
+			if (curr->desktops[j] == desktop) {
+				return curr;
 			}
 		}
-		current_monitor = current_monitor->next;
+		curr = curr->next;
 	}
 	return NULL;
 }
@@ -2322,11 +2344,6 @@ static int
 ewmh_update_number_of_desktops(void)
 {
 	uint32_t desktops_count	 = 0;
-	// for (int i = 0; i < wm->n_of_monitors; i++) {
-	// 	if (wm->monitors[i] ) {
-	// 		desktops_count += wm->monitors[i]->n_of_desktops;
-	// 	}
-	// }
 	desktops_count			 = prim_monitor->n_of_desktops;
 	xcb_void_cookie_t cookie = xcb_ewmh_set_number_of_desktops_checked(
 		wm->ewmh, wm->screen_nbr, desktops_count);
@@ -2435,9 +2452,9 @@ setup_wm(void)
 		_LOG_(ERROR, "error while setting up ewmh");
 		return false;
 	}
-	// load_cursors();
-	// set_cursor(CURSOR_POINTER);
-	// init_pointer();
+	/* load_cursors(); */
+	/* set_cursor(CURSOR_POINTER); */
+	/* init_pointer(); */
 
 	return true;
 }
@@ -2449,11 +2466,10 @@ resize_window(xcb_window_t win, uint16_t width, uint16_t height)
 		return 0;
 
 	const uint32_t	  values[] = {width, height};
-
 	xcb_void_cookie_t cookie =
-		xcb_configure_window_checked(wm->connection, win, XCB_RESIZE, values);
-	xcb_generic_error_t *err = xcb_request_check(wm->connection, cookie);
+		xcb_configure_window_checked(wm->connection, win, RESIZE, values);
 
+	xcb_generic_error_t *err = xcb_request_check(wm->connection, cookie);
 	if (err) {
 		_LOG_(ERROR,
 			  "error resizing window (ID %u): %s",
@@ -2475,7 +2491,7 @@ move_window(xcb_window_t win, int16_t x, int16_t y)
 
 	const uint32_t	  values[] = {x, y};
 	xcb_void_cookie_t cookie =
-		xcb_configure_window_checked(wm->connection, win, XCB_MOVE, values);
+		xcb_configure_window_checked(wm->connection, win, MOVE, values);
 	xcb_generic_error_t *err = xcb_request_check(wm->connection, cookie);
 
 	if (err) {
@@ -2566,7 +2582,7 @@ hide_bar(xcb_window_t win)
 	arrange_trees();
 }
 
-// TODO: rewrite this
+/* TODO: rewrite this */
 static int
 change_border_attr(xcb_conn_t  *conn,
 				   xcb_window_t win,
@@ -3101,8 +3117,8 @@ find_window_in_desktops(desktop_t  **curr_desktop,
 {
 	monitor_t *curr = head_monitor;
 	while (curr) {
-		for (int i = 0; i < curr_monitor->n_of_desktops; i++) {
-			desktop_t *d = curr_monitor->desktops[i];
+		for (int i = 0; i < curr->n_of_desktops; i++) {
+			desktop_t *d = curr->desktops[i];
 			node_t	  *n = find_node_by_window_id(d->tree, win);
 			if (n) {
 				*curr_desktop = d;
@@ -3169,7 +3185,7 @@ kill_window(xcb_window_t win)
 	client_t  *c			   = (n) ? n->client : NULL;
 	bool	   another_desktop = false;
 	if (c == NULL) {
-		// window isn't in current desktop
+		/* window isn't in current desktop */
 		find_window_in_desktops(&d, &n, win, &another_desktop);
 		c = (n) ? n->client : NULL;
 		if (c == NULL) {
@@ -3590,8 +3606,8 @@ find_desktop_by_window(xcb_window_t win)
 {
 	monitor_t *curr = head_monitor;
 	while (curr) {
-		for (int i = 0; i < curr_monitor->n_of_desktops; i++) {
-			desktop_t *d = curr_monitor->desktops[i];
+		for (int i = 0; i < curr->n_of_desktops; i++) {
+			desktop_t *d = curr->desktops[i];
 			node_t	  *n = find_node_by_window_id(d->tree, win);
 			if (n) {
 				return d->id;
@@ -3602,96 +3618,78 @@ find_desktop_by_window(xcb_window_t win)
 	return -1;
 }
 
-static int
+static ewmh_window_type_t
+determine_window_type(xcb_ewmh_connection_t *ewmh, xcb_atom_t atom)
+{
+	if (atom == ewmh->_NET_WM_WINDOW_TYPE_NORMAL) {
+		/* WINDOW_TYPE_NORMAL indicates a normal, top-level window.
+		 * This is the default window type for standard application windows.*/
+		return WINDOW_TYPE_NORMAL;
+	} else if (atom == ewmh->_NET_WM_WINDOW_TYPE_DOCK) {
+		/* WINDOW_TYPE_DOCK indicates a dock or panel feature.
+		 * Typically, a Window Manager would keep such windows on top of all
+		 * other windows. Examples include system trays, taskbars, or desktop
+		 * panels. */
+		return WINDOW_TYPE_DOCK;
+	} else if (atom == ewmh->_NET_WM_WINDOW_TYPE_TOOLBAR ||
+			   atom == ewmh->_NET_WM_WINDOW_TYPE_MENU) {
+		/* WINDOW_TYPE_TOOLBAR_MENU represents toolbar and pinnable menu
+		 * windows. These are toolbars and menus "torn off" from the main
+		 * application. Windows of this type may set the WM_TRANSIENT_FOR hint
+		 * indicating the main application window.*/
+		return WINDOW_TYPE_TOOLBAR_MENU;
+	} else if (atom == ewmh->_NET_WM_WINDOW_TYPE_UTILITY) {
+		/* WINDOW_TYPE_UTILITY indicates a small persistent utility window.
+		 * Examples include palettes or toolboxes that:
+		 * - Are distinct from toolbars (not torn off from main app)
+		 * - Differ from dialogs (not transient)
+		 * - Users typically keep open while working
+		 * May set WM_TRANSIENT_FOR hint to main application window.*/
+		return WINDOW_TYPE_UTILITY;
+	} else if (atom == ewmh->_NET_WM_WINDOW_TYPE_SPLASH) {
+		/* WINDOW_TYPE_SPLASH represents a splash screen
+		 * displayed as an application is starting up.
+		 * Typically shown briefly during application initialization. */
+		return WINDOW_TYPE_SPLASH;
+	} else if (atom == ewmh->_NET_WM_WINDOW_TYPE_DIALOG) {
+		/* WINDOW_TYPE_DIALOG indicates a dialog window.
+		 * If NETWM_WINDOW_TYPE is not set, windows with
+		 * WM_TRANSIENT_FOR hint MUST be treated as this type.
+		 * Temporary windows for user interaction, input, or notifications. */
+		return WINDOW_TYPE_DIALOG;
+	} else if (atom == ewmh->_NET_WM_WINDOW_TYPE_NOTIFICATION) {
+		/* WINDOW_TYPE_NOTIFICATION represents a notification window.
+		 * Examples include informative bubbles like:
+		 * "Your laptop is running out of power"
+		 * Typically used on override-redirect windows. */
+		return WINDOW_TYPE_NOTIFICATION;
+	}
+	return WINDOW_TYPE_NORMAL;
+}
+
+static ewmh_window_type_t
 window_type(xcb_window_t win)
 {
 	xcb_ewmh_get_atoms_reply_t w_type;
 	xcb_get_property_cookie_t  c = xcb_ewmh_get_wm_window_type(wm->ewmh, win);
+
 	const uint8_t			   r =
 		xcb_ewmh_get_wm_window_type_reply(wm->ewmh, c, &w_type, NULL);
 
-	if (r == 1) {
-		for (unsigned int i = 0; i < w_type.atoms_len; ++i) {
-			const xcb_atom_t a = w_type.atoms[i];
-			if (a == wm->ewmh->_NET_WM_WINDOW_TYPE_NORMAL) {
-				/*
-				 * _NET_WM_WINDOW_TYPE_NORMAL
-				 * indicates that this is a normal, top-level window.
-				 * */
-				xcb_ewmh_get_atoms_reply_wipe(&w_type);
-				return 1;
-			} else if (a == wm->ewmh->_NET_WM_WINDOW_TYPE_DOCK) {
-				/*
-				 * _NET_WM_WINDOW_TYPE_DOCK
-				 * indicates a dock or panel feature.
-				 * Typically, a Window Manager would keep such windows
-				 * on top of all other windows.
-				 * */
-				xcb_ewmh_get_atoms_reply_wipe(&w_type);
-				return 2;
-			} else if (a == wm->ewmh->_NET_WM_WINDOW_TYPE_TOOLBAR ||
-					   a == wm->ewmh->_NET_WM_WINDOW_TYPE_MENU) {
-				/*
-				 * _NET_WM_WINDOW_TYPE_TOOLBAR and
-				 * _NET_WM_WINDOW_TYPE_MENU indicate toolbar and
-				 * pinnable menu windows, respectively (i.e. toolbars
-				 * and menus "torn off" from the main application).
-				 * Windows of this type may set the WM_TRANSIENT_FOR
-				 * hint indicating the main application window.
-				 * */
-				xcb_ewmh_get_atoms_reply_wipe(&w_type);
-				return 3;
-			} else if (a == wm->ewmh->_NET_WM_WINDOW_TYPE_UTILITY) {
-				/*
-				 * _NET_WM_WINDOW_TYPE_UTILITY
-				 * indicates a small persistent utility window, such
-				 * as a palette or toolbox. It is distinct from type
-				 * TOOLBAR because it does not correspond to a toolbar
-				 * torn off from the main application. It's distinct
-				 * from type DIALOG because it isn't a transient
-				 * dialog, the user will probably keep it open while
-				 * they're working. Windows of this type may set the
-				 * WM_TRANSIENT_FOR hint indicating the main
-				 * application window.
-				 * */
-				xcb_ewmh_get_atoms_reply_wipe(&w_type);
-				return 4;
-			} else if (a == wm->ewmh->_NET_WM_WINDOW_TYPE_SPLASH) {
-				/*
-				 * _NET_WM_WINDOW_TYPE_SPLASH
-				 * indicates that the window is a splash screen
-				 * displayed as an application is starting up.
-				 * */
-				xcb_ewmh_get_atoms_reply_wipe(&w_type);
-				return 5;
-			} else if (a == wm->ewmh->_NET_WM_WINDOW_TYPE_DIALOG) {
-				/*
-				 * _NET_WM_WINDOW_TYPE_DIALOG
-				 * indicates that this is a dialog window.
-				 * If _NET_WM_WINDOW_TYPE is not set,
-				 * then windows with WM_TRANSIENT_FOR set MUST be
-				 * taken as this type.
-				 * */
-				xcb_ewmh_get_atoms_reply_wipe(&w_type);
-				return 6;
-			} else if (a == wm->ewmh->_NET_WM_WINDOW_TYPE_NOTIFICATION) {
-				/*
-				 * _NET_WM_WINDOW_TYPE_NOTIFICATION
-				 * indicates a notification. An example of a
-				 * notification would be a bubble appearing with
-				 * informative text such as "Your laptop is running
-				 * out of power" etc. This property is typically used
-				 * on override-redirect windows.
-				 * */
-				xcb_ewmh_get_atoms_reply_wipe(&w_type);
-				return 7;
-			} else {
-				xcb_ewmh_get_atoms_reply_wipe(&w_type);
-				return 1;
-			}
+	if (r != 1) {
+		return WINDOW_TYPE_UNKNOWN;
+	}
+
+	ewmh_window_type_t type = WINDOW_TYPE_NORMAL;
+	for (unsigned int i = 0; i < w_type.atoms_len; ++i) {
+		type = determine_window_type(wm->ewmh, w_type.atoms[i]);
+		if (type != WINDOW_TYPE_NORMAL) {
+			break;
 		}
 	}
-	return -1;
+
+	xcb_ewmh_get_atoms_reply_wipe(&w_type);
+	return type;
 }
 
 static bool
@@ -3989,69 +3987,6 @@ insert_into_desktop(int idx, xcb_window_t win, bool is_tiled)
 }
 
 static int
-handle_map_request(const xcb_map_request_event_t *ev)
-{
-	xcb_window_t win = ev->window;
-
-	monitor_t	*mm	 = get_focused_monitor();
-	if (mm && mm != curr_monitor) {
-		curr_monitor = mm;
-	}
-
-	if (!should_manage(win, wm->connection)) {
-		_LOG_(INFO, "win %d, shouldn't be managed.. ignoring request", win);
-		return 0;
-	}
-
-	int idx = get_focused_desktop_idx();
-	if (idx == -1) {
-		_LOG_(ERROR, "cannot get focused desktop idx");
-		return idx;
-	}
-
-	// check if the window already exists in the tree to avoid duplication
-	if (find_node_by_window_id(curr_monitor->desktops[idx]->tree, win) !=
-		NULL) {
-		return 0;
-	}
-
-	desktop_t *d	= curr_monitor->desktops[idx];
-	rule_t	  *rule = get_window_rule(win);
-
-	if (rule) {
-		if (rule->desktop_id != -1) {
-			return insert_into_desktop(
-				rule->desktop_id, win, rule->state == TILED);
-		}
-		if (rule->state == FLOATING) {
-			return handle_floating_window_request(win, d);
-		} else if (rule->state == TILED) {
-			return handle_tiled_window_request(win, d);
-		}
-	}
-
-	int wint = window_type(win);
-	if ((apply_floating_hints(win) != -1 && wint != 2)) {
-		return handle_floating_window_request(win, d);
-	}
-	if (wint == 7) {
-		map_floating(win);
-		return 0;
-	}
-	switch (wint) {
-	case -1:
-	case 0:
-	case 1: return handle_tiled_window_request(win, d);
-	case 2: return handle_bar_request(win, d);
-	case 3:
-	case 4:
-	case 5:
-	case 6: return handle_floating_window_request(win, d);
-	default: return 0;
-	}
-}
-
-static int
 handle_tiled_window_request(xcb_window_t win, desktop_t *d)
 {
 	client_t *client = create_client(win, XCB_ATOM_WINDOW, wm->connection);
@@ -4124,10 +4059,75 @@ handle_bar_request(xcb_window_t win, desktop_t *d)
 }
 
 static int
-handle_enter_notify(const xcb_enter_notify_event_t *ev)
+handle_map_request(const xcb_generic_event_t *event)
 {
-	xcb_window_t win = ev->event;
-	monitor_t	*mm	 = get_focused_monitor();
+	xcb_map_request_event_t *ev	 = (xcb_map_request_event_t *)event;
+	xcb_window_t			 win = ev->window;
+
+	monitor_t				*mm	 = get_focused_monitor();
+	if (mm && mm != curr_monitor) {
+		curr_monitor = mm;
+	}
+
+	if (!should_manage(win, wm->connection)) {
+		_LOG_(INFO, "win %d, shouldn't be managed.. ignoring request", win);
+		return 0;
+	}
+
+	int idx = get_focused_desktop_idx();
+	if (idx == -1) {
+		_LOG_(ERROR, "cannot get focused desktop idx");
+		return idx;
+	}
+
+	/* check if the window already exists in the tree to avoid duplication */
+	if (find_node_by_window_id(curr_monitor->desktops[idx]->tree, win) !=
+		NULL) {
+		return 0;
+	}
+
+	desktop_t *d	= curr_monitor->desktops[idx];
+	rule_t	  *rule = get_window_rule(win);
+
+	if (rule) {
+		if (rule->desktop_id != -1) {
+			return insert_into_desktop(
+				rule->desktop_id, win, rule->state == TILED);
+		}
+		if (rule->state == FLOATING) {
+			return handle_floating_window_request(win, d);
+		} else if (rule->state == TILED) {
+			return handle_tiled_window_request(win, d);
+		}
+	}
+
+	ewmh_window_type_t wint = window_type(win);
+	if ((apply_floating_hints(win) != -1 && wint != WINDOW_TYPE_DOCK)) {
+		return handle_floating_window_request(win, d);
+	}
+	if (wint == WINDOW_TYPE_NOTIFICATION) {
+		map_floating(win);
+		return 0;
+	}
+	switch (wint) {
+	case WINDOW_TYPE_UNKNOWN:
+	case WINDOW_TYPE_NORMAL: return handle_tiled_window_request(win, d);
+	case WINDOW_TYPE_DOCK: return handle_bar_request(win, d);
+	case WINDOW_TYPE_TOOLBAR_MENU:
+	case WINDOW_TYPE_UTILITY:
+	case WINDOW_TYPE_SPLASH:
+	case WINDOW_TYPE_DIALOG: return handle_floating_window_request(win, d);
+	default: return 0;
+	}
+}
+
+static int
+handle_enter_notify(const xcb_generic_event_t *event)
+{
+	xcb_enter_notify_event_t *ev  = (xcb_enter_notify_event_t *)event;
+	xcb_window_t			  win = ev->event;
+
+	monitor_t				 *mm  = get_focused_monitor();
 	if (mm && mm != curr_monitor) {
 		curr_monitor = mm;
 	}
@@ -4172,7 +4172,6 @@ handle_enter_notify(const xcb_enter_notify_event_t *ev)
 	if (!conf.focus_follow_pointer) {
 		if (has_floating_window(root)) {
 			restack();
-			// restackv2(root);
 		}
 		if (IS_FULLSCREEN(n->client)) {
 			if (fullscreen_focus(n->client->window)) {
@@ -4180,7 +4179,7 @@ handle_enter_notify(const xcb_enter_notify_event_t *ev)
 				return -1;
 			}
 		}
-		// set_cursor(CURSOR_NOT_ALLOWED);
+		/* set_cursor(CURSOR_NOT_ALLOWED); */
 		return 0;
 	}
 
@@ -4232,13 +4231,13 @@ handle_enter_notify(const xcb_enter_notify_event_t *ev)
 }
 
 static int
-handle_leave_notify(const xcb_leave_notify_event_t *ev)
+handle_leave_notify(const xcb_generic_event_t *event)
 {
 	if (!conf.focus_follow_pointer) {
 		return 0;
 	}
-
-	xcb_window_t win = ev->event;
+	xcb_leave_notify_event_t *ev  = (xcb_leave_notify_event_t *)event;
+	xcb_window_t			  win = ev->event;
 
 #ifdef _DEBUG__
 	char *name = win_name(win);
@@ -4292,11 +4291,12 @@ handle_leave_notify(const xcb_leave_notify_event_t *ev)
 	return 0;
 }
 
-static void
-handle_key_press(const xcb_key_press_event_t *key_press)
+static int
+handle_key_press(const xcb_generic_event_t *event)
 {
-	uint16_t	 cleaned_state = (key_press->state & ~(XCB_MOD_MASK_LOCK));
-	xcb_keysym_t k			   = get_keysym(key_press->detail, wm->connection);
+	xcb_key_press_event_t *ev			 = (xcb_key_press_event_t *)event;
+	uint16_t			   cleaned_state = (ev->state & ~(XCB_MOD_MASK_LOCK));
+	xcb_keysym_t		   k = get_keysym(ev->detail, wm->connection);
 
 	if (key_head) {
 		_LOG_(INFO, "----grabbing conf keys------");
@@ -4304,8 +4304,8 @@ handle_key_press(const xcb_key_press_event_t *key_press)
 		while (current) {
 			if (cleaned_state == (current->mod & ~(XCB_MOD_MASK_LOCK))) {
 				if (current->keysym == k) {
-					arg_t *a   = current->arg;
-					int	   ret = current->function_ptr(a);
+					arg_t	 *a	  = current->arg;
+					const int ret = current->function_ptr(a);
 					if (ret != 0) {
 						_LOG_(ERROR, "error while executing function_ptr(..)");
 					}
@@ -4314,16 +4314,15 @@ handle_key_press(const xcb_key_press_event_t *key_press)
 			}
 			current = current->next;
 		}
-		return;
+		return 0;
 	}
 
-	// _LOG_(INFO, "----using default keys------");
 	size_t n = sizeof(keys_) / sizeof(keys_[0]);
 	for (size_t i = n; i--;) {
 		if (cleaned_state == (keys_[i].mod & ~(XCB_MOD_MASK_LOCK))) {
 			if (keys_[i].keysym == k) {
-				arg_t *a   = keys_[i].arg;
-				int	   ret = keys_[i].function_ptr(a);
+				arg_t	 *a	  = keys_[i].arg;
+				const int ret = keys_[i].function_ptr(a);
 				if (ret != 0) {
 					_LOG_(ERROR, "error while executing function_ptr(..)");
 				}
@@ -4331,6 +4330,7 @@ handle_key_press(const xcb_key_press_event_t *key_press)
 			}
 		}
 	}
+	return 0;
 }
 
 static int
@@ -4404,19 +4404,15 @@ handle_state(node_t		 *n,
 }
 
 static int
-handle_client_message(const xcb_client_message_event_t *client_message)
+handle_client_message(const xcb_generic_event_t *event)
 {
-
+	xcb_client_message_event_t *ev = (xcb_client_message_event_t *)event;
 #ifdef _DEBUG__
-	char *name = win_name(client_message->window);
-	_LOG_(DEBUG,
-		  "recieved client message for %d, name %s ",
-		  client_message->window,
-		  name);
+	char *name = win_name(ev->window);
+	_LOG_(DEBUG, "recieved client message for %d, name %s ", ev->window, name);
 	_FREE_(name);
 #endif
-
-	if (client_message->format != 32) {
+	if (ev->format != 32) {
 		return 0;
 	}
 
@@ -4425,18 +4421,17 @@ handle_client_message(const xcb_client_message_event_t *client_message)
 		return d;
 
 	node_t *root = curr_monitor->desktops[d]->tree;
-
-	node_t *n	 = find_node_by_window_id(root, client_message->window);
-	// node_t reciever fonctions will perform the null check for n
+	/* reciever fonctions will perform the null check for n */
+	node_t *n	 = find_node_by_window_id(root, ev->window);
 #ifdef _DEBUG__
-	_LOG_(DEBUG, "received data32 for win %d:", client_message->window);
-	for (ulong i = 0; i < LEN(client_message->data.data32); i++) {
-		_LOG_(DEBUG, "data32[%d]: %u", i, client_message->data.data32[i]);
+	_LOG_(DEBUG, "received data32 for win %d:", ev->window);
+	for (ulong i = 0; i < LEN(ev->data.data32); i++) {
+		_LOG_(DEBUG, "data32[%d]: %u", i, ev->data.data32[i]);
 	}
 #endif
-	char *s = win_name(client_message->window);
-	if (client_message->type == wm->ewmh->_NET_CURRENT_DESKTOP) {
-		uint32_t nd = client_message->data.data32[0];
+	char *s = win_name(ev->window);
+	if (ev->type == wm->ewmh->_NET_CURRENT_DESKTOP) {
+		uint32_t nd = ev->data.data32[0];
 		_LOG_(INFO, "recieved desktop change to %d", nd);
 		if (nd > wm->ewmh->_NET_NUMBER_OF_DESKTOPS - 1) {
 			return -1;
@@ -4445,20 +4440,16 @@ handle_client_message(const xcb_client_message_event_t *client_message)
 			_FREE_(s);
 			return -1;
 		}
-	} else if (client_message->type == wm->ewmh->_NET_CLOSE_WINDOW) {
-		_LOG_(INFO, "window want to be closed %d", client_message->window);
-	} else if (client_message->type == wm->ewmh->_NET_WM_STATE) {
-		_LOG_(INFO, "wm_state for %d name %s", client_message->window, s);
-		handle_state(n,
-					 client_message->data.data32[1],
-					 client_message->data.data32[2],
-					 client_message->data.data32[0]);
-	} else if (client_message->type == wm->ewmh->_NET_ACTIVE_WINDOW) {
-		_LOG_(INFO,
-			  "wm_state _NET_ACTIVE_WINDOW for %d name %s",
-			  client_message->window,
-			  s);
-		int di = find_desktop_by_window(client_message->window);
+	} else if (ev->type == wm->ewmh->_NET_CLOSE_WINDOW) {
+		_LOG_(INFO, "window want to be closed %d", ev->window);
+	} else if (ev->type == wm->ewmh->_NET_WM_STATE) {
+		_LOG_(INFO, "wm_state for %d name %s", ev->window, s);
+		handle_state(
+			n, ev->data.data32[1], ev->data.data32[2], ev->data.data32[0]);
+	} else if (ev->type == wm->ewmh->_NET_ACTIVE_WINDOW) {
+		_LOG_(
+			INFO, "wm_state _NET_ACTIVE_WINDOW for %d name %s", ev->window, s);
+		int di = find_desktop_by_window(ev->window);
 		if (di == -1)
 			goto out;
 
@@ -4466,44 +4457,33 @@ handle_client_message(const xcb_client_message_event_t *client_message)
 			_FREE_(s);
 			return -1;
 		}
-	} else if (client_message->type ==
-			   wm->ewmh->_NET_WM_STATE_DEMANDS_ATTENTION) {
+	} else if (ev->type == wm->ewmh->_NET_WM_STATE_DEMANDS_ATTENTION) {
 		_LOG_(INFO,
 			  "wm_state _NET_WM_STATE_DEMANDS_ATTENTION for %d name %s",
-			  client_message->window,
+			  ev->window,
 			  s);
-	} else if (client_message->type == wm->ewmh->_NET_WM_STATE_STICKY) {
+	} else if (ev->type == wm->ewmh->_NET_WM_STATE_STICKY) {
 		_LOG_(INFO,
 			  "wm_state _NET_WM_STATE_STICKY for %d name %s",
-			  client_message->window,
+			  ev->window,
 			  s);
-	} else if (client_message->type == wm->ewmh->_NET_WM_DESKTOP) {
-		_LOG_(INFO,
-			  "wm_state _NET_WM_DESKTOP for %d name %s",
-			  client_message->window,
-			  s);
-	} else if (client_message->type == wm->ewmh->_NET_CLOSE_WINDOW) {
-		_LOG_(INFO,
-			  "wm_state _NET_CLOSE_WINDOW for %d name %s",
-			  client_message->window,
-			  s);
-		close_or_kill(client_message->window);
+	} else if (ev->type == wm->ewmh->_NET_WM_DESKTOP) {
+		_LOG_(INFO, "wm_state _NET_WM_DESKTOP for %d name %s", ev->window, s);
+	} else if (ev->type == wm->ewmh->_NET_CLOSE_WINDOW) {
+		_LOG_(INFO, "wm_state _NET_CLOSE_WINDOW for %d name %s", ev->window, s);
+		close_or_kill(ev->window);
 	}
-	// TODO: ewmh->_NET_WM_STATE
-	// TODO: ewmh->_NET_CLOSE_WINDOW
-	// TODO: ewmh->_NET_WM_DESKTOP
-	// TODO: ewmh->_NET_WM_STATE_FULLSCREEN
-	// TODO: ewmh->_NET_ACTIVE_WINDOW
 out:
 	_FREE_(s);
 	return 0;
 }
 
 static int
-handle_unmap_notify(xcb_unmap_notify_event_t *ev)
+handle_unmap_notify(const xcb_generic_event_t *event)
 {
-	xcb_window_t win = ev->window;
-	int			 idx = get_focused_desktop_idx();
+	xcb_unmap_notify_event_t *ev  = (xcb_unmap_notify_event_t *)event;
+	xcb_window_t			  win = ev->window;
+	int						  idx = get_focused_desktop_idx();
 	if (idx == -1)
 		return -1;
 
@@ -4540,37 +4520,36 @@ handle_unmap_notify(xcb_unmap_notify_event_t *ev)
 	return 0;
 }
 
-static void
-handle_configure_request(const xcb_configure_request_event_t *e)
+static int
+handle_configure_request(const xcb_generic_event_t *event)
 {
-	xcb_window_t						win = e->window;
+	xcb_configure_request_event_t *ev  = (xcb_configure_request_event_t *)event;
+	xcb_window_t				   win = ev->window;
 
 	xcb_icccm_get_text_property_reply_t t_reply;
 	xcb_get_property_cookie_t			cn =
-		xcb_icccm_get_wm_name(wm->connection, e->window);
+		xcb_icccm_get_wm_name(wm->connection, ev->window);
 	const uint8_t wr =
 		xcb_icccm_get_wm_name_reply(wm->connection, cn, &t_reply, NULL);
 	char name[256];
 	if (wr == 1) {
 		snprintf(name, sizeof(name), "%s", t_reply.name);
 		xcb_icccm_get_text_property_reply_wipe(&t_reply);
-	} else {
-		return;
 	}
 #ifdef _DEBUG__
 	_LOG_(DEBUG,
 		  "window %d  name %s wants to be at %dx%d with %dx%d",
 		  win,
 		  name,
-		  e->x,
-		  e->y,
-		  e->width,
-		  e->height);
+		  ev->x,
+		  ev->y,
+		  ev->width,
+		  ev->height);
 #endif
 
 	const int d = get_focused_desktop_idx();
 	if (d == -1) {
-		return;
+		return d;
 	}
 
 	node_t *n		   = curr_monitor->desktops[d]->tree;
@@ -4579,59 +4558,61 @@ handle_configure_request(const xcb_configure_request_event_t *e)
 		uint16_t mask = 0;
 		uint32_t values[7];
 		uint16_t i = 0;
-		if (e->value_mask & XCB_CONFIG_WINDOW_X) {
+		if (ev->value_mask & XCB_CONFIG_WINDOW_X) {
 			mask |= XCB_CONFIG_WINDOW_X;
-			values[i++] = (uint32_t)e->x;
+			values[i++] = (uint32_t)ev->x;
 		}
 
-		if (e->value_mask & XCB_CONFIG_WINDOW_Y) {
+		if (ev->value_mask & XCB_CONFIG_WINDOW_Y) {
 			mask |= XCB_CONFIG_WINDOW_Y;
-			values[i++] = (uint32_t)e->y;
+			values[i++] = (uint32_t)ev->y;
 		}
 
-		if (e->value_mask & XCB_CONFIG_WINDOW_WIDTH) {
+		if (ev->value_mask & XCB_CONFIG_WINDOW_WIDTH) {
 			mask |= XCB_CONFIG_WINDOW_WIDTH;
-			values[i++] = e->width;
+			values[i++] = ev->width;
 		}
 
-		if (e->value_mask & XCB_CONFIG_WINDOW_HEIGHT) {
+		if (ev->value_mask & XCB_CONFIG_WINDOW_HEIGHT) {
 			mask |= XCB_CONFIG_WINDOW_HEIGHT;
-			values[i++] = e->height;
+			values[i++] = ev->height;
 		}
 
-		if (e->value_mask & XCB_CONFIG_WINDOW_BORDER_WIDTH) {
+		if (ev->value_mask & XCB_CONFIG_WINDOW_BORDER_WIDTH) {
 			mask |= XCB_CONFIG_WINDOW_BORDER_WIDTH;
-			values[i++] = e->border_width;
+			values[i++] = ev->border_width;
 		}
 
-		if (e->value_mask & XCB_CONFIG_WINDOW_SIBLING) {
+		if (ev->value_mask & XCB_CONFIG_WINDOW_SIBLING) {
 			mask |= XCB_CONFIG_WINDOW_SIBLING;
-			values[i++] = e->sibling;
+			values[i++] = ev->sibling;
 		}
 
-		if (e->value_mask & XCB_CONFIG_WINDOW_STACK_MODE) {
+		if (ev->value_mask & XCB_CONFIG_WINDOW_STACK_MODE) {
 			mask |= XCB_CONFIG_WINDOW_STACK_MODE;
-			values[i++] = e->stack_mode;
+			values[i++] = ev->stack_mode;
 		}
 
 		xcb_configure_window(wm->connection, win, mask, values);
 	} else {
-		const node_t *node = find_node_by_window_id(n, e->window);
+		const node_t *node = find_node_by_window_id(n, ev->window);
 		if (node == NULL) {
 			_LOG_(ERROR,
 				  "config request -> cannot find node with win id %d",
-				  e->window);
-			return;
+				  ev->window);
+			return 0;
 		}
 		// TODO: deal with *node
 	}
+	return 0;
 }
 
 static int
-handle_destroy_notify(const xcb_destroy_notify_event_t *ev)
+handle_destroy_notify(const xcb_generic_event_t *event)
 {
-	xcb_window_t win = ev->window;
-	int			 idx = get_focused_desktop_idx();
+	xcb_destroy_notify_event_t *ev	= (xcb_destroy_notify_event_t *)event;
+	xcb_window_t				win = ev->window;
+	int							idx = get_focused_desktop_idx();
 	if (idx == -1)
 		return -1;
 
@@ -4684,12 +4665,13 @@ update_grabbed_window(node_t *root, node_t *n)
 	update_grabbed_window(root->second_child, n);
 }
 
-static void
-handle_button_press_event(const xcb_button_press_event_t *ev)
+static int
+handle_button_press_event(const xcb_generic_event_t *event)
 {
 	if (conf.focus_follow_pointer) {
-		return;
+		return 0;
 	}
+	xcb_button_press_event_t *ev = (xcb_button_press_event_t *)event;
 #ifdef _DEBUG__
 	char *name = win_name(ev->event);
 	_LOG_(DEBUG,
@@ -4698,76 +4680,62 @@ handle_button_press_event(const xcb_button_press_event_t *ev)
 		  name);
 	_FREE_(name);
 #endif
-	/* bool replay = false; */
-	/* for (unsigned int i = 0; i < LEN(buttons_); i++) { */
-	/* 	if (ev->detail != buttons_[i]) { */
-	/* 		continue; */
-	/* 	} */
-	/* 	if ((click_to_focus == (int8_t)XCB_BUTTON_INDEX_ANY || */
-	/* 		 click_to_focus == (int8_t)buttons_[i]) && */
-	/* 		(ev->state & ~(num_lock | scroll_lock | caps_lock)) == */
-	/* 			XCB_NONE) { */
-	/* 	} */
-	/* } */
-
 	xcb_window_t win = ev->event;
 
 	if (wm->bar && win == wm->bar->window) {
-		return;
+		return 0;
 	}
 
 	if (!window_exists(wm->connection, win)) {
-		return;
+		return 0;
 	}
 
 	const int curd = get_focused_desktop_idx();
 	if (curd == -1)
-		return;
+		return -1;
 
 	node_t	 *root	 = curr_monitor->desktops[curd]->tree;
 	node_t	 *n		 = find_node_by_window_id(root, win);
 	client_t *client = (n && n->client) ? n->client : NULL;
 
 	if (client == NULL) {
-		return;
+		return -1;
 	}
 
 	if (win == wm->root_window) {
-		return;
+		return 0;
 	}
 
-	// update_grabbed_window(root, n);
-	// update_focus(root, n);
 	window_ungrab_buttons(client->window);
 
 	const int r = set_active_window_name(win);
 	if (r != 0) {
-		return;
+		return 0;
 	}
 
 	if (IS_FLOATING(n->client)) {
 		if (win_focus(n->client->window, true) != 0) {
 			_LOG_(ERROR, "cannot focus window %d (enter)", n->client->window);
-			return;
+			return -1;
 		}
 		n->is_focused = true;
 	} else if (IS_FULLSCREEN(n->client)) {
 		if (fullscreen_focus(n->client->window)) {
 			_LOG_(ERROR, "cannot update win attributes");
-			return;
+			return -1;
 		}
 	} else {
 		if (curr_monitor->desktops[curd]->layout == STACK) {
 			if (win_focus(n->client->window, true) != 0) {
 				_LOG_(
 					ERROR, "cannot focus window %d (enter)", n->client->window);
-				return;
+				return -1;
 			}
 			n->is_focused = true;
 		} else {
 			if (set_focus(n, true) != 0) {
 				_LOG_(ERROR, "cannot focus node (enter)");
-				return;
+				return -1;
 			}
 		}
 	}
@@ -4780,15 +4748,18 @@ handle_button_press_event(const xcb_button_press_event_t *ev)
 	}
 
 	xcb_allow_events(wm->connection, XCB_ALLOW_SYNC_POINTER, ev->time);
-	// set_cursor(CURSOR_POINTER);
+	/* set_cursor(CURSOR_POINTER); */
 	xcb_flush(wm->connection);
+	return 0;
 }
 
 static int
-handle_mapping_notify(const xcb_mapping_notify_event_t *e)
+handle_mapping_notify(const xcb_generic_event_t *event)
 {
-	if (e->request != XCB_MAPPING_KEYBOARD &&
-		e->request != XCB_MAPPING_MODIFIER) {
+	xcb_mapping_notify_event_t *ev = (xcb_mapping_notify_event_t *)event;
+
+	if (ev->request != XCB_MAPPING_KEYBOARD &&
+		ev->request != XCB_MAPPING_MODIFIER) {
 		return 0;
 	}
 
@@ -4800,6 +4771,41 @@ handle_mapping_notify(const xcb_mapping_notify_event_t *e)
 	if (0 != grab_keys(wm->connection, wm->root_window)) {
 		_LOG_(ERROR, "cannot grab keys");
 		return -1;
+	}
+
+	return 0;
+}
+
+static int
+handle_motion_notify(const xcb_generic_event_t *event)
+{
+	xcb_motion_notify_event_t *ev = (xcb_motion_notify_event_t *)event;
+	_LOG_(INFO,
+		  "recevied motion notify on root %dx%d even %dx%d",
+		  ev->root_x,
+		  ev->root_y,
+		  ev->event_x,
+		  ev->event_y);
+	/* skip events where the pointer was over a child window, we are only
+	 * interested in events on the root window. */
+	if (ev->child != XCB_NONE) {
+		return 0;
+	}
+	int16_t	   rx = ev->root_x;
+	int16_t	   ry = ev->root_y;
+	int16_t	   ex = ev->event_x;
+	int16_t	   ey = ev->event_y;
+	/* find out if this crosses monitor boundary */
+	monitor_t *m  = get_monitor_within_coordinate(rx, ry);
+	if (!m) {
+		_LOG_(
+			INFO, "cannot find monitor crossing from this event %dx%d", rx, ry);
+	} else {
+		_LOG_(INFO,
+			  "found monitor %s crossing from this event %dx%d",
+			  m->name,
+			  rx,
+			  ry);
 	}
 
 	return 0;
@@ -4837,7 +4843,6 @@ log_children(xcb_conn_t *conn, xcb_window_t root_window)
 static void
 parse_args(int argc, char **argv)
 {
-	// quick and dirty approach
 	char *c = NULL;
 	if (strcmp(argv[1], "-r") == 0 || strcmp(argv[1], "-run") == 0) {
 		if (argc >= 2) {
@@ -4849,149 +4854,64 @@ parse_args(int argc, char **argv)
 	exec_process(&((arg_t){.argc = 1, .cmd = (char *[]){c}}));
 }
 
+static const char *
+xcb_event_to_string(uint8_t type)
+{
+	switch (type) {
+	case XCB_MAP_REQUEST: return "XCB_MAP_REQUEST";
+	case XCB_UNMAP_NOTIFY: return "XCB_UNMAP_NOTIFY";
+	case XCB_DESTROY_NOTIFY: return "XCB_DESTROY_NOTIFY";
+	case XCB_EXPOSE: return "XCB_EXPOSE";
+	case XCB_CLIENT_MESSAGE: return "XCB_CLIENT_MESSAGE";
+	case XCB_CONFIGURE_REQUEST: return "XCB_CONFIGURE_REQUEST";
+	case XCB_CONFIGURE_NOTIFY: return "XCB_CONFIGURE_NOTIFY";
+	case XCB_PROPERTY_NOTIFY: return "XCB_PROPERTY_NOTIFY";
+	case XCB_ENTER_NOTIFY: return "XCB_ENTER_NOTIFY";
+	case XCB_LEAVE_NOTIFY: return "XCB_LEAVE_NOTIFY";
+	case XCB_MOTION_NOTIFY: return "XCB_MOTION_NOTIFY";
+	case XCB_BUTTON_PRESS: return "XCB_BUTTON_PRESS";
+	case XCB_BUTTON_RELEASE: return "XCB_BUTTON_RELEASE";
+	case XCB_KEY_PRESS: return "XCB_KEY_PRESS";
+	case XCB_KEY_RELEASE: return "XCB_KEY_RELEASE";
+	case XCB_FOCUS_IN: return "XCB_FOCUS_IN";
+	case XCB_FOCUS_OUT: return "XCB_FOCUS_OUT";
+	case XCB_MAPPING_NOTIFY: return "XCB_MAPPING_NOTIFY";
+	default: return "UNKNOWN_EVENT";
+	}
+}
+
+static int
+handle_event(xcb_generic_event_t *event)
+{
+	uint8_t event_type = event->response_type & ~0x80;
+
+	if (using_xrandr &&
+		event_type == randr_base + XCB_RANDR_SCREEN_CHANGE_NOTIFY) {
+		_LOG_(INFO, "monitor update was requested");
+		handle_monitor_changes();
+		return 0;
+	}
+
+	size_t n = sizeof(event_handlers) / sizeof(event_handlers[0]);
+	for (size_t i = 0; i < n; i++) {
+		if (event_handlers[i].type == event_type) {
+			return event_handlers[i].handler(event);
+		}
+	}
+
+	return 0;
+}
+
 static void
 event_loop(wm_t *w)
 {
 	xcb_generic_event_t *event;
 	while ((event = xcb_wait_for_event(w->connection))) {
-		switch (event->response_type & ~0x80) {
-		case XCB_MAP_REQUEST: {
-			xcb_map_request_event_t *map_request =
-				(xcb_map_request_event_t *)event;
-			if (handle_map_request(map_request) != 0) {
-				_LOG_(ERROR,
-					  "failed to handle MAP_REQUEST for window %d",
-					  map_request->window);
-			}
-			break;
-		}
-		case XCB_UNMAP_NOTIFY: {
-			xcb_unmap_notify_event_t *unmap_notify =
-				(xcb_unmap_notify_event_t *)event;
-			if (handle_unmap_notify(unmap_notify) != 0) {
-				_LOG_(ERROR,
-					  "failed to handle XCB_UNMAP_NOTIFY for "
-					  "window %d",
-					  unmap_notify->window);
-			}
-			break;
-		}
-		case XCB_DESTROY_NOTIFY: {
-			xcb_destroy_notify_event_t *destroy_notify =
-				(xcb_destroy_notify_event_t *)event;
-			if (handle_destroy_notify(destroy_notify) != 0) {
-				_LOG_(ERROR,
-					  "failed to handle XCB_DESTROY_NOTIFY for "
-					  "window %d",
-					  destroy_notify->window);
-			}
-			break;
-		}
-		case XCB_EXPOSE: {
-			__attribute__((unused)) xcb_expose_event_t *expose_event =
-				(xcb_expose_event_t *)event;
-			break;
-		}
-		case XCB_CLIENT_MESSAGE: {
-			xcb_client_message_event_t *client_message =
-				(xcb_client_message_event_t *)event;
-			handle_client_message(client_message);
-			break;
-		}
-		case XCB_CONFIGURE_REQUEST: {
-			xcb_configure_request_event_t *config_request =
-				(xcb_configure_request_event_t *)event;
-			handle_configure_request(config_request);
-			break;
-		}
-		case XCB_CONFIGURE_NOTIFY: {
-			__attribute__((unused))
-			xcb_configure_notify_event_t *config_notify =
-				(xcb_configure_notify_event_t *)event;
-			break;
-		}
-		case XCB_PROPERTY_NOTIFY: {
-			__attribute__((unused))
-			xcb_property_notify_event_t *property_notify =
-				(xcb_property_notify_event_t *)event;
-			break;
-		}
-		case XCB_ENTER_NOTIFY: {
-			xcb_enter_notify_event_t *enter_event =
-				(xcb_enter_notify_event_t *)event;
-			if (handle_enter_notify(enter_event) != 0) {
-				_LOG_(ERROR,
-					  "failed to handle XCB_ENTER_NOTIFY for "
-					  "window %d",
-					  enter_event->event);
-			}
-			break;
-		}
-		case XCB_LEAVE_NOTIFY: {
-			__attribute__((unused)) xcb_leave_notify_event_t *leave_event =
-				(xcb_leave_notify_event_t *)event;
-			// if (handle_leave_notify(leave_event) != 0) {
-			// 	_LOG_(ERROR,
-			// 				"Failed to handle XCB_LEAVE_NOTIFY for "
-			// 				"window %d",
-			// 				leave_event->event);
-			// }
-			break;
-		}
-		case XCB_MOTION_NOTIFY: {
-			__attribute__((unused)) xcb_motion_notify_event_t *motion_notify =
-				(xcb_motion_notify_event_t *)event;
-			break;
-		}
-		case XCB_BUTTON_PRESS: {
-			xcb_button_press_event_t *button_press =
-				(xcb_button_press_event_t *)event;
-			handle_button_press_event(button_press);
-			break;
-		}
-		case XCB_BUTTON_RELEASE: {
-			__attribute__((unused)) xcb_button_release_event_t *button_release =
-				(xcb_button_release_event_t *)event;
-			break;
-		}
-		case XCB_KEY_PRESS: {
-			xcb_key_press_event_t *key_press = (xcb_key_press_event_t *)event;
-			handle_key_press(key_press);
-			break;
-		}
-		case XCB_KEY_RELEASE: {
-			__attribute__((unused)) xcb_key_release_event_t *key_release =
-				(xcb_key_release_event_t *)event;
-			break;
-		}
-		case XCB_FOCUS_IN: {
-			__attribute__((unused)) xcb_focus_in_event_t *focus_in_event =
-				(xcb_focus_in_event_t *)event;
-			break;
-		}
-		case XCB_FOCUS_OUT: {
-			__attribute__((unused)) xcb_focus_out_event_t *focus_out_event =
-				(xcb_focus_out_event_t *)event;
-			break;
-		}
-		case XCB_MAPPING_NOTIFY: {
-			xcb_mapping_notify_event_t *mapping_notify =
-				(xcb_mapping_notify_event_t *)event;
-			handle_mapping_notify(mapping_notify);
-			break;
-		}
-		default: {
-			if (using_xrandr) {
-				if ((event->response_type & ~0x80) ==
-					randr_base + XCB_RANDR_SCREEN_CHANGE_NOTIFY) {
-					_LOG_(INFO, "monitor update was requested");
-					handle_monitor_changes();
-					// xrandr --output eDP1 --auto --output HDMI1 --auto
-					// --right-of eDP1
-				}
-			}
-			break;
-		}
+		int r = handle_event(event);
+		if (r != 0) {
+			uint8_t		type = event->response_type & ~0x80;
+			const char *en	 = xcb_event_to_string(type);
+			_LOG_(ERROR, "error processing event: %s ", en);
 		}
 		free(event);
 	}
@@ -5004,12 +4924,12 @@ cleanup(int sig)
 	xcb_ewmh_connection_wipe(wm->ewmh);
 	free_keys();
 	free_rules();
-	free_monitors(); // frees desktops and trees as well
+	free_monitors(); /* frees desktops and trees as well */
 	_FREE_(wm);
 	_LOG_(INFO, "ZWM exits with signal number %d", sig);
-	// uncommenting the following line *exit(sig)* prevents the os
-	// from generating a core dump file when zwm crashes
-	// exit(sig);
+	/* uncommenting the following line *exit(sig)* prevents the os
+	 * from generating a core dump file when zwm crashes */
+	/* exit(sig); */
 }
 
 int

--- a/src/zwm.c
+++ b/src/zwm.c
@@ -51,19 +51,24 @@
 #include <xcb/xinerama.h>
 #include <xcb/xproto.h>
 
-#define XCB_MOVE_RESIZE                                                   \
-	(XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y |                          \
-	 XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT)
-#define XCB_MOVE   (XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y)
-#define XCB_RESIZE (XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT)
-#define SUBSTRUCTURE_REDIRECTION                                          \
-	(XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY |                                 \
-	 XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT)
-#define CLIENT_EVENT_MASK                                                 \
-	(XCB_EVENT_MASK_PROPERTY_CHANGE | XCB_EVENT_MASK_FOCUS_CHANGE |       \
+#define WINDOW_X				 XCB_CONFIG_WINDOW_X
+#define WINDOW_Y				 XCB_CONFIG_WINDOW_Y
+#define WINDOW_W				 XCB_CONFIG_WINDOW_WIDTH
+#define WINDOW_H				 XCB_CONFIG_WINDOW_HEIGHT
+#define S_NOTIFY				 XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY
+#define S_REDIRECT				 XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT
+
+#define XCB_MOVE_RESIZE			 (WINDOW_X | WINDOW_Y | WINDOW_W | WINDOW_H)
+#define XCB_MOVE				 (WINDOW_X | WINDOW_Y)
+#define XCB_RESIZE				 (WINDOW_W | WINDOW_H)
+#define SUBSTRUCTURE_REDIRECTION (S_NOTIFY | S_REDIRECT)
+
+#define CLIENT_EVENT_MASK                                                      \
+	(XCB_EVENT_MASK_PROPERTY_CHANGE | XCB_EVENT_MASK_FOCUS_CHANGE |            \
 	 XCB_EVENT_MASK_ENTER_WINDOW | XCB_EVENT_MASK_LEAVE_WINDOW)
-#define ROOT_EVENT_MASK                                                   \
-	(SUBSTRUCTURE_REDIRECTION | XCB_EVENT_MASK_BUTTON_PRESS |             \
+
+#define ROOT_EVENT_MASK                                                        \
+	(SUBSTRUCTURE_REDIRECTION | XCB_EVENT_MASK_BUTTON_PRESS |                  \
 	 XCB_EVENT_MASK_FOCUS_CHANGE | XCB_EVENT_MASK_ENTER_WINDOW)
 
 #define NUMBER_OF_DESKTOPS 7
@@ -82,7 +87,7 @@ xcb_window_t		  focused_win	 = XCB_NONE;
 xcb_window_t		  meta_window	 = XCB_NONE;
 bool				  is_kgrabbed	 = false;
 monitor_t			 *prim_monitor	 = NULL;
-monitor_t			 *cur_monitor	 = NULL;
+monitor_t			 *curr_monitor	 = NULL;
 monitor_t			 *head_monitor	 = NULL;
 bool				  using_xrandr	 = false;
 bool				  using_xinerama = false;
@@ -172,27 +177,29 @@ static int handle_bar_request(xcb_window_t, desktop_t *);
 static int show_window(xcb_window_t win);
 static int hide_window(xcb_window_t win);
 static xcb_get_geometry_reply_t *get_geometry(xcb_window_t win, xcb_conn_t *conn);
+static bool setup_desktops(void);
+static node_t *get_foucsed_desktop_tree(void);
 // clang-format on
 
 static void
 load_cursors(void)
 {
-	if (xcb_cursor_context_new(wm->connection, wm->screen, &cursor_ctx) <
-		0) {
+	if (xcb_cursor_context_new(wm->connection, wm->screen, &cursor_ctx) < 0) {
 		_LOG_(ERROR, "failed to allocate xcursor context");
 		return;
 	}
-#define _LOAD_CURSOR_(cursor, name)                                       \
-	do {                                                                  \
-		cursors[cursor] = xcb_cursor_load_cursor(cursor_ctx, name);       \
+	/* _LOAD_CURSOR_ is reserved by some other lib */
+#define __LOAD__CURSOR__(cursor, name)                                         \
+	do {                                                                       \
+		cursors[cursor] = xcb_cursor_load_cursor(cursor_ctx, name);            \
 	} while (0)
-	_LOAD_CURSOR_(CURSOR_POINTER, "left_ptr");
-	_LOAD_CURSOR_(CURSOR_WATCH, "watch");
-	_LOAD_CURSOR_(CURSOR_MOVE, "fleur");
-	_LOAD_CURSOR_(CURSOR_XTERM, "xterm");
-	_LOAD_CURSOR_(CURSOR_NOT_ALLOWED, "not-allowed");
-	_LOAD_CURSOR_(CURSOR_HAND2, "hand2");
-#undef _LOAD_CURSOR_
+	__LOAD__CURSOR__(CURSOR_POINTER, "left_ptr");
+	__LOAD__CURSOR__(CURSOR_WATCH, "watch");
+	__LOAD__CURSOR__(CURSOR_MOVE, "fleur");
+	__LOAD__CURSOR__(CURSOR_XTERM, "xterm");
+	__LOAD__CURSOR__(CURSOR_NOT_ALLOWED, "not-allowed");
+	__LOAD__CURSOR__(CURSOR_HAND2, "hand2");
+#undef __LOAD__CURSOR__
 }
 
 static xcb_cursor_t
@@ -212,9 +219,7 @@ set_cursor(int cursor_id)
 	xcb_generic_error_t *err = xcb_request_check(wm->connection, cookie);
 
 	if (err) {
-		_LOG_(ERROR,
-			  "Error setting cursor on root window %d\n",
-			  err->error_code);
+		_LOG_(ERROR, "Error setting cursor on root window %d", err->error_code);
 		free(err);
 	}
 	xcb_flush(wm->connection);
@@ -225,9 +230,8 @@ char *
 win_name(xcb_window_t win)
 {
 	xcb_icccm_get_text_property_reply_t t_reply;
-	xcb_get_property_cookie_t			cn =
-		xcb_icccm_get_wm_name(wm->connection, win);
-	const uint8_t wr =
+	xcb_get_property_cookie_t cn = xcb_icccm_get_wm_name(wm->connection, win);
+	const uint8_t			  wr =
 		xcb_icccm_get_wm_name_reply(wm->connection, cn, &t_reply, NULL);
 
 	if (wr == 1) {
@@ -254,7 +258,7 @@ layout_handler(arg_t *arg)
 		return -1;
 	}
 
-	desktop_t *d = cur_monitor->desktops[i];
+	desktop_t *d = curr_monitor->desktops[i];
 
 	if (arg->t == STACK && d->n_count < 2)
 		return 0;
@@ -262,16 +266,46 @@ layout_handler(arg_t *arg)
 	return render_tree(d->tree);
 }
 
+static node_t *
+get_foucsed_desktop_tree(void)
+{
+	int idx = get_focused_desktop_idx();
+	if (idx == -1)
+		return NULL;
+	node_t *root = curr_monitor->desktops[idx]->tree;
+	if (root == NULL)
+		return NULL;
+	return root;
+}
+
+static void
+render_trees(void)
+{
+	monitor_t *curr = head_monitor;
+	while (curr) {
+		if (!curr->desktops) {
+			curr = curr->next;
+			continue;
+		}
+		for (int i = 0; i < curr->n_of_desktops; i++) {
+			if (!curr->desktops[i]->is_focused)
+				continue;
+			if (is_tree_empty(curr->desktops[i]->tree))
+				continue;
+			render_tree(curr->desktops[i]->tree);
+		}
+		curr = curr->next;
+	}
+}
+
 int
 change_state(arg_t *arg)
 {
-	xcb_window_t w =
-		get_window_under_cursor(wm->connection, wm->root_window);
+	xcb_window_t w = get_window_under_cursor(wm->connection, wm->root_window);
 	if (w == XCB_NONE)
 		return -1;
 
-	int		idx	 = get_focused_desktop_idx();
-	node_t *root = cur_monitor->desktops[idx]->tree;
+	node_t *root = get_foucsed_desktop_tree();
 	if (root == NULL)
 		return -1;
 
@@ -298,8 +332,7 @@ change_state(arg_t *arg)
 				(parent->rectangle.width -
 				 (conf.window_gap - conf.border_width)) /
 				2;
-			parent->first_child->rectangle.height =
-				parent->rectangle.height;
+			parent->first_child->rectangle.height = parent->rectangle.height;
 
 			parent->second_child->rectangle.x =
 				(int16_t)(parent->rectangle.x +
@@ -307,11 +340,9 @@ change_state(arg_t *arg)
 						  conf.window_gap + conf.border_width);
 			parent->second_child->rectangle.y = parent->rectangle.y;
 			parent->second_child->rectangle.width =
-				parent->rectangle.width -
-				parent->first_child->rectangle.width - conf.window_gap -
-				conf.border_width;
-			parent->second_child->rectangle.height =
-				parent->rectangle.height;
+				parent->rectangle.width - parent->first_child->rectangle.width -
+				conf.window_gap - conf.border_width;
+			parent->second_child->rectangle.height = parent->rectangle.height;
 		} else {
 			parent->first_child->rectangle.x	 = parent->rectangle.x;
 			parent->first_child->rectangle.y	 = parent->rectangle.y;
@@ -326,8 +357,7 @@ change_state(arg_t *arg)
 				(int16_t)(parent->rectangle.y +
 						  parent->first_child->rectangle.height +
 						  conf.window_gap + conf.border_width);
-			parent->second_child->rectangle.width =
-				parent->rectangle.width;
+			parent->second_child->rectangle.width = parent->rectangle.width;
 			parent->second_child->rectangle.height =
 				parent->rectangle.height -
 				parent->first_child->rectangle.height - conf.window_gap -
@@ -346,10 +376,10 @@ change_state(arg_t *arg)
 			get_geometry(n->client->window, wm->connection);
 		int h  = g->height / 2;
 		int wi = g->width / 2;
-		int x  = cur_monitor->rectangle.x +
-				(cur_monitor->rectangle.width / 2) - (wi / 2);
-		int y = cur_monitor->rectangle.y +
-				(cur_monitor->rectangle.height / 2) - (h / 2);
+		int x  = curr_monitor->rectangle.x +
+				(curr_monitor->rectangle.width / 2) - (wi / 2);
+		int y = curr_monitor->rectangle.y +
+				(curr_monitor->rectangle.height / 2) - (h / 2);
 		rectangle_t rc		  = {.x = x, .y = y, .width = wi, .height = h};
 		n->floating_rectangle = rc;
 		free(g);
@@ -405,8 +435,7 @@ ewmh_set_supporting(xcb_window_t win, xcb_ewmh_connection_t *ewmh)
 {
 	pid_t			  wm_pid = getpid();
 	xcb_void_cookie_t supporting_cookie_root =
-		xcb_ewmh_set_supporting_wm_check_checked(
-			ewmh, wm->root_window, win);
+		xcb_ewmh_set_supporting_wm_check_checked(ewmh, wm->root_window, win);
 	xcb_void_cookie_t supporting_cookie =
 		xcb_ewmh_set_supporting_wm_check_checked(ewmh, win, win);
 	xcb_void_cookie_t name_cookie =
@@ -415,28 +444,23 @@ ewmh_set_supporting(xcb_window_t win, xcb_ewmh_connection_t *ewmh)
 		xcb_ewmh_set_wm_pid_checked(ewmh, win, (uint32_t)wm_pid);
 
 	xcb_generic_error_t *err;
-	if ((err = xcb_request_check(ewmh->connection,
-								 supporting_cookie_root))) {
-		_LOG_(ERROR,
-			  "Error setting supporting window: %d\n",
-			  err->error_code);
+	if ((err = xcb_request_check(ewmh->connection, supporting_cookie_root))) {
+		_LOG_(ERROR, "Error setting supporting window: %d", err->error_code);
 		free(err);
 		return -1;
 	}
 	if ((err = xcb_request_check(ewmh->connection, supporting_cookie))) {
-		_LOG_(ERROR,
-			  "Error setting supporting window: %d\n",
-			  err->error_code);
+		_LOG_(ERROR, "Error setting supporting window: %d", err->error_code);
 		free(err);
 		return -1;
 	}
 	if ((err = xcb_request_check(ewmh->connection, name_cookie))) {
-		fprintf(stderr, "Error setting WM name: %d\n", err->error_code);
+		fprintf(stderr, "Error setting WM name: %d", err->error_code);
 		free(err);
 		return -1;
 	}
 	if ((err = xcb_request_check(ewmh->connection, pid_cookie))) {
-		fprintf(stderr, "Error setting WM PID: %d\n", err->error_code);
+		fprintf(stderr, "Error setting WM PID: %d", err->error_code);
 		free(err);
 		return -1;
 	}
@@ -447,16 +471,16 @@ ewmh_set_supporting(xcb_window_t win, xcb_ewmh_connection_t *ewmh)
 int
 get_focused_desktop_idx(void)
 {
-	if (cur_monitor == NULL) {
-		_LOG_(ERROR, "cur_monitor is null\n");
+	if (curr_monitor == NULL) {
+		_LOG_(ERROR, "curr_monitor is null");
 		return -1;
 	}
-	for (int i = cur_monitor->n_of_desktops; i--;) {
-		if (cur_monitor->desktops[i]->is_focused) {
-			return cur_monitor->desktops[i]->id;
+	for (int i = curr_monitor->n_of_desktops; i--;) {
+		if (curr_monitor->desktops[i]->is_focused) {
+			return curr_monitor->desktops[i]->id;
 		}
 	}
-	_LOG_(ERROR, "cannot find curr monitor focused desktop\n");
+	_LOG_(ERROR, "cannot find curr monitor focused desktop");
 	return -1;
 }
 
@@ -465,7 +489,7 @@ get_focused_desktop(void)
 {
 	monitor_t *focused_monitor = get_focused_monitor();
 	for (int i = focused_monitor->n_of_desktops; i--;) {
-		if (focused_monitor->desktops[i] != NULL &&
+		if (focused_monitor->desktops[i] &&
 			focused_monitor->desktops[i]->is_focused) {
 			return focused_monitor->desktops[i];
 		}
@@ -483,9 +507,7 @@ ewmh_set_number_of_desktops(xcb_ewmh_connection_t *ewmh,
 		xcb_ewmh_set_number_of_desktops_checked(ewmh, screen_nbr, nd);
 	xcb_generic_error_t *err = xcb_request_check(ewmh->connection, cookie);
 	if (err) {
-		_LOG_(ERROR,
-			  "Error setting number of desktops: %d\n",
-			  err->error_code);
+		_LOG_(ERROR, "Error setting number of desktops: %d", err->error_code);
 		free(err);
 		return -1;
 	}
@@ -520,9 +542,7 @@ ewmh_update_desktop_names(void)
 		wm->ewmh, wm->screen_nbr, names_len, names);
 	xcb_generic_error_t *err = xcb_request_check(wm->ewmh->connection, c);
 	if (err) {
-		_LOG_(ERROR,
-			  "Error setting names of desktops: %d\n",
-			  err->error_code);
+		_LOG_(ERROR, "Error setting names of desktops: %d", err->error_code);
 		free(err);
 		return -1;
 	}
@@ -532,26 +552,22 @@ ewmh_update_desktop_names(void)
 static int16_t
 modfield_from_keysym(xcb_keysym_t keysym)
 {
-	uint16_t	   modfield = 0;
-	xcb_keycode_t *keycodes = NULL, *mod_keycodes = NULL;
+	uint16_t						  modfield = 0;
+	xcb_keycode_t					 *keycodes = NULL, *mod_keycodes = NULL;
 	xcb_get_modifier_mapping_reply_t *reply = NULL;
 	xcb_key_symbols_t *symbols = xcb_key_symbols_alloc(wm->connection);
 
-	if ((keycodes = xcb_key_symbols_get_keycode(symbols, keysym)) ==
-			NULL ||
+	if ((keycodes = xcb_key_symbols_get_keycode(symbols, keysym)) == NULL ||
 		(reply = xcb_get_modifier_mapping_reply(
-			 wm->connection,
-			 xcb_get_modifier_mapping(wm->connection),
-			 NULL)) == NULL ||
+			 wm->connection, xcb_get_modifier_mapping(wm->connection), NULL)) ==
+			NULL ||
 		reply->keycodes_per_modifier < 1 ||
-		(mod_keycodes = xcb_get_modifier_mapping_keycodes(reply)) ==
-			NULL) {
+		(mod_keycodes = xcb_get_modifier_mapping_keycodes(reply)) == NULL) {
 		goto end;
 	}
 
-	unsigned int num_mod =
-		xcb_get_modifier_mapping_keycodes_length(reply) /
-		reply->keycodes_per_modifier;
+	unsigned int num_mod = xcb_get_modifier_mapping_keycodes_length(reply) /
+						   reply->keycodes_per_modifier;
 	for (unsigned int i = 0; i < num_mod; i++) {
 		for (unsigned int j = 0; j < reply->keycodes_per_modifier; j++) {
 			xcb_keycode_t mk =
@@ -601,7 +617,6 @@ remove_property(xcb_connection_t *con,
 			if (atoms[i] != atom)
 				values[num++] = atoms[i];
 		}
-
 		xcb_change_property(con,
 							XCB_PROP_MODE_REPLACE,
 							win,
@@ -625,13 +640,12 @@ window_above(xcb_window_t win1, xcb_window_t win2)
 	if (win2 == XCB_NONE) {
 		return;
 	}
-	uint16_t mask =
-		XCB_CONFIG_WINDOW_SIBLING | XCB_CONFIG_WINDOW_STACK_MODE;
-	uint32_t		  values[] = {win2, XCB_STACK_MODE_ABOVE};
+	uint16_t mask = XCB_CONFIG_WINDOW_SIBLING | XCB_CONFIG_WINDOW_STACK_MODE;
+	uint32_t values[] = {win2, XCB_STACK_MODE_ABOVE};
 	xcb_void_cookie_t cookie =
 		xcb_configure_window_checked(wm->connection, win1, mask, values);
 	xcb_generic_error_t *err = xcb_request_check(wm->connection, cookie);
-	if (err != NULL) {
+	if (err) {
 		_LOG_(ERROR,
 			  "in stacking window %d: error code %d",
 			  win2,
@@ -647,13 +661,12 @@ window_below(xcb_window_t win1, xcb_window_t win2)
 	if (win2 == XCB_NONE) {
 		return;
 	}
-	uint16_t mask =
-		XCB_CONFIG_WINDOW_SIBLING | XCB_CONFIG_WINDOW_STACK_MODE;
-	uint32_t		  values[] = {win2, XCB_STACK_MODE_BELOW};
+	uint16_t mask = XCB_CONFIG_WINDOW_SIBLING | XCB_CONFIG_WINDOW_STACK_MODE;
+	uint32_t values[] = {win2, XCB_STACK_MODE_BELOW};
 	xcb_void_cookie_t cookie =
 		xcb_configure_window_checked(wm->connection, win1, mask, values);
 	xcb_generic_error_t *err = xcb_request_check(wm->connection, cookie);
-	if (err != NULL) {
+	if (err) {
 		_LOG_(ERROR,
 			  "in stacking window %d: error code %d",
 			  win2,
@@ -667,11 +680,10 @@ lower_window(xcb_window_t win)
 {
 	uint32_t		  values[] = {XCB_STACK_MODE_BELOW};
 	uint16_t		  mask	   = XCB_CONFIG_WINDOW_STACK_MODE;
-
 	xcb_void_cookie_t cookie =
 		xcb_configure_window_checked(wm->connection, win, mask, values);
 	xcb_generic_error_t *err = xcb_request_check(wm->connection, cookie);
-	if (err != NULL) {
+	if (err) {
 		_LOG_(ERROR,
 			  "in stacking window %d: error code %d",
 			  win,
@@ -685,11 +697,10 @@ raise_window(xcb_window_t win)
 {
 	uint32_t		  values[] = {XCB_STACK_MODE_ABOVE};
 	uint16_t		  mask	   = XCB_CONFIG_WINDOW_STACK_MODE;
-
 	xcb_void_cookie_t cookie =
 		xcb_configure_window_checked(wm->connection, win, mask, values);
 	xcb_generic_error_t *err = xcb_request_check(wm->connection, cookie);
-	if (err != NULL) {
+	if (err) {
 		_LOG_(ERROR,
 			  "in stacking window %d: error code %d",
 			  win,
@@ -701,21 +712,16 @@ raise_window(xcb_window_t win)
 int
 swap_node_wrapper()
 {
-	if (cur_monitor == NULL) {
+	if (curr_monitor == NULL) {
 		_LOG_(ERROR, "Failed to swap node, current monitor is NULL");
 		return -1;
 	}
-	int idx = get_focused_desktop_idx();
-	if (idx == -1) {
-		_LOG_(ERROR, "Failed to swap node, cannot find focused desktop");
-		return -1;
-	}
-	node_t *root = cur_monitor->desktops[idx]->tree;
+
+	node_t *root = get_foucsed_desktop_tree();
 	if (root == NULL)
 		return -1;
 
-	xcb_window_t w =
-		get_window_under_cursor(wm->connection, wm->root_window);
+	xcb_window_t w = get_window_under_cursor(wm->connection, wm->root_window);
 	if (w == wm->root_window) {
 		return 0;
 	}
@@ -734,13 +740,7 @@ swap_node_wrapper()
 int
 shift_floating_window(arg_t *arg)
 {
-	int idx = get_focused_desktop_idx();
-	if (idx == -1) {
-		_LOG_(ERROR, "Failed to shift node, cannot find focused desktop");
-		return -1;
-	}
-
-	node_t *root = cur_monitor->desktops[idx]->tree;
+	node_t *root = get_foucsed_desktop_tree();
 	if (root == NULL)
 		return -1;
 
@@ -754,16 +754,16 @@ shift_floating_window(arg_t *arg)
 	if (n == NULL)
 		return -1;
 
-	if (n->client != NULL && n->client->state != FLOATING)
+	if (n->client && n->client->state != FLOATING)
 		return 0;
 
 	const int16_t pxl			 = 10;
 	int16_t		  new_x			 = n->floating_rectangle.x;
 	int16_t		  new_y			 = n->floating_rectangle.y;
-	int16_t		  monitor_x		 = cur_monitor->rectangle.x;
-	int16_t		  monitor_y		 = cur_monitor->rectangle.y;
-	int16_t		  monitor_width	 = cur_monitor->rectangle.width;
-	int16_t		  monitor_height = cur_monitor->rectangle.height;
+	int16_t		  monitor_x		 = curr_monitor->rectangle.x;
+	int16_t		  monitor_y		 = curr_monitor->rectangle.y;
+	int16_t		  monitor_width	 = curr_monitor->rectangle.width;
+	int16_t		  monitor_height = curr_monitor->rectangle.height;
 
 	switch (arg->d) {
 	case LEFT:
@@ -774,8 +774,7 @@ shift_floating_window(arg_t *arg)
 		break;
 	case RIGHT:
 		new_x += pxl;
-		if (new_x + n->floating_rectangle.width >
-			monitor_x + monitor_width) {
+		if (new_x + n->floating_rectangle.width > monitor_x + monitor_width) {
 			return 0;
 		}
 		break;
@@ -787,8 +786,7 @@ shift_floating_window(arg_t *arg)
 		break;
 	case DOWN:
 		new_y += pxl;
-		if (new_y + n->floating_rectangle.height >
-			monitor_y + monitor_height) {
+		if (new_y + n->floating_rectangle.height > monitor_y + monitor_height) {
 			return 0;
 		}
 		break;
@@ -809,18 +807,11 @@ shift_floating_window(arg_t *arg)
 int
 set_fullscreen_wrapper()
 {
-	const int i = get_focused_desktop_idx();
-	if (i == -1) {
-		_LOG_(ERROR, "Failed to swap node, cannot find focused desktop");
-		return -1;
-	}
-
-	node_t *root = cur_monitor->desktops[i]->tree;
+	node_t *root = get_foucsed_desktop_tree();
 	if (root == NULL)
 		return -1;
 
-	xcb_window_t w =
-		get_window_under_cursor(wm->connection, wm->root_window);
+	xcb_window_t w = get_window_under_cursor(wm->connection, wm->root_window);
 
 	if (w == wm->root_window) {
 		return 0;
@@ -846,10 +837,10 @@ set_fullscreen(node_t *n, bool flag)
 
 	if (flag) {
 		long data[]		 = {wm->ewmh->_NET_WM_STATE_FULLSCREEN};
-		r.x				 = cur_monitor->rectangle.x;
-		r.y				 = cur_monitor->rectangle.y;
-		r.width			 = cur_monitor->rectangle.width;
-		r.height		 = cur_monitor->rectangle.height;
+		r.x				 = curr_monitor->rectangle.x;
+		r.y				 = curr_monitor->rectangle.y;
+		r.width			 = curr_monitor->rectangle.width;
+		r.height		 = curr_monitor->rectangle.height;
 		n->client->state = FULLSCREEN;
 		if (change_border_attr(wm->connection,
 							   n->client->window,
@@ -873,9 +864,7 @@ set_fullscreen(node_t *n, bool flag)
 										data);
 		xcb_generic_error_t *err = xcb_request_check(wm->connection, c);
 		if (err) {
-			_LOG_(ERROR,
-				  "Error changing window property: %d\n",
-				  err->error_code);
+			_LOG_(ERROR, "Error changing window property: %d", err->error_code);
 			free(err);
 			return -1;
 		}
@@ -905,7 +894,7 @@ set_fullscreen(node_t *n, bool flag)
 	// 								wm->ewmh->_NET_WM_STATE_FULLSCREEN);
 	// xcb_generic_error_t *err = xcb_request_check(wm->connection,
 	// c); if (err) { 	_LOG_(ERROR, 				"Error removing
-	// window property: %d\n", 				err->error_code);
+	// window property: %d", 				err->error_code);
 	// free(err); 	return -1;
 	// }
 out:
@@ -919,16 +908,16 @@ change_colors(node_t *root)
 	if (root == NULL)
 		return 0;
 
-	if (root->node_type != INTERNAL_NODE && root->client != NULL) {
+	if (root->node_type != INTERNAL_NODE && root->client) {
 		if (win_focus(root->client->window, root->is_focused) != 0) {
 			_LOG_(ERROR, "cannot focus node");
 			return -1;
 		}
 	}
 
-	if (root->first_child != NULL)
+	if (root->first_child)
 		change_colors(root->first_child);
-	if (root->second_child != NULL)
+	if (root->second_child)
 		change_colors(root->second_child);
 
 	return 0;
@@ -938,101 +927,87 @@ static void
 apply_monitor_layout_changes(monitor_t *m)
 {
 	for (int d = 0; d < m->n_of_desktops; ++d) {
-		if (m->desktops[d] != NULL) {
-			if (!is_tree_empty(m->desktops[d]->tree)) {
-				layout_t l	  = m->desktops[d]->layout;
-				node_t	*tree = m->desktops[d]->tree;
-				if (l == DEFAULT) {
-					rectangle_t	   r = {0};
-					uint16_t	   w = m->rectangle.width;
-					uint16_t	   h = m->rectangle.height;
-					const uint16_t x = m->rectangle.x;
-					const uint16_t y = m->rectangle.y;
-					if (wm->bar != NULL && m == prim_monitor) {
-						r.x = x + conf.window_gap;
-						r.y = y + wm->bar->rectangle.height +
-							  conf.window_gap;
-						r.width = w - 2 * conf.window_gap -
-								  2 * conf.border_width;
-						r.height = h - wm->bar->rectangle.height -
-								   2 * conf.window_gap -
-								   2 * conf.border_width;
-					} else {
-						r.x		= x + conf.window_gap;
-						r.y		= y + conf.window_gap;
-						r.width = w - 2 * conf.window_gap -
-								  2 * conf.border_width;
-						r.height = h - 2 * conf.window_gap -
-								   2 * conf.border_width;
-					}
-					tree->rectangle = r;
-					apply_default_layout(tree);
-				} else if (l == MASTER) {
-					node_t		  *ms			= find_master_node(tree);
-					const double   ratio		= 0.70;
-					uint16_t	   w			= m->rectangle.width;
-					uint16_t	   h			= m->rectangle.height;
-					const uint16_t x			= m->rectangle.x;
-					const uint16_t y			= m->rectangle.y;
-					uint16_t	   master_width = w * ratio;
-					uint16_t	   r_width = (uint16_t)(w * (1 - ratio));
-					if (ms == NULL) {
-						ms = find_any_leaf(tree);
-						if (ms == NULL) {
-							return;
-						}
-					}
-					ms->is_master = true;
-					uint16_t bar_height =
-						wm->bar == NULL ? 0 : wm->bar->rectangle.height;
-					rectangle_t r1 = {
-						.x = x + conf.window_gap,
-						.y = (int16_t)(y + bar_height + conf.window_gap),
-						.width =
-							(uint16_t)(master_width - 2 * conf.window_gap),
-						.height = (uint16_t)(h - 2 * conf.window_gap -
-											 bar_height),
-					};
-					rectangle_t r2 = {
-						.x = (x + master_width),
-						.y = (int16_t)(y + bar_height + conf.window_gap),
-						.width =
-							(uint16_t)(r_width - (1 * conf.window_gap)),
-						.height = (uint16_t)(h - 2 * conf.window_gap -
-											 bar_height),
-					};
-					ms->rectangle	= r1;
-					tree->rectangle = r2;
-					apply_master_layout(tree);
-				} else if (l == STACK) {
-					rectangle_t	   r = {0};
-					uint16_t	   w = m->rectangle.width;
-					uint16_t	   h = m->rectangle.height;
-					const uint16_t x = m->rectangle.x;
-					const uint16_t y = m->rectangle.y;
-					if (wm->bar != NULL && m == prim_monitor) {
-						r.x = x + conf.window_gap;
-						r.y = y + wm->bar->rectangle.height +
-							  conf.window_gap;
-						r.width = w - 2 * conf.window_gap -
-								  2 * conf.border_width;
-						r.height = h - wm->bar->rectangle.height -
-								   2 * conf.window_gap -
-								   2 * conf.border_width;
-					} else {
-						r.x		= x + conf.window_gap;
-						r.y		= y + conf.window_gap;
-						r.width = w - 2 * conf.window_gap -
-								  2 * conf.border_width;
-						r.height = h - 2 * conf.window_gap -
-								   2 * conf.border_width;
-					}
-					tree->rectangle = r;
-					apply_stack_layout(tree);
-				} else if (l == GRID) {
-					// todo
+		if (!m->desktops[d])
+			continue;
+		if (is_tree_empty(m->desktops[d]->tree))
+			continue;
+		layout_t l	  = m->desktops[d]->layout;
+		node_t	*tree = m->desktops[d]->tree;
+		if (l == DEFAULT) {
+			rectangle_t	   r = {0};
+			uint16_t	   w = m->rectangle.width;
+			uint16_t	   h = m->rectangle.height;
+			const uint16_t x = m->rectangle.x;
+			const uint16_t y = m->rectangle.y;
+			if (wm->bar && m == prim_monitor) {
+				r.x		 = x + conf.window_gap;
+				r.y		 = y + wm->bar->rectangle.height + conf.window_gap;
+				r.width	 = w - 2 * conf.window_gap - 2 * conf.border_width;
+				r.height = h - wm->bar->rectangle.height - 2 * conf.window_gap -
+						   2 * conf.border_width;
+			} else {
+				r.x		 = x + conf.window_gap;
+				r.y		 = y + conf.window_gap;
+				r.width	 = w - 2 * conf.window_gap - 2 * conf.border_width;
+				r.height = h - 2 * conf.window_gap - 2 * conf.border_width;
+			}
+			tree->rectangle = r;
+			apply_default_layout(tree);
+		} else if (l == MASTER) {
+			node_t		  *ms			= find_master_node(tree);
+			const double   ratio		= 0.70;
+			uint16_t	   w			= m->rectangle.width;
+			uint16_t	   h			= m->rectangle.height;
+			const uint16_t x			= m->rectangle.x;
+			const uint16_t y			= m->rectangle.y;
+			uint16_t	   master_width = w * ratio;
+			uint16_t	   r_width		= (uint16_t)(w * (1 - ratio));
+			if (ms == NULL) {
+				ms = find_any_leaf(tree);
+				if (ms == NULL) {
+					return;
 				}
 			}
+			ms->is_master = true;
+			uint16_t bar_height =
+				wm->bar == NULL ? 0 : wm->bar->rectangle.height;
+			rectangle_t r1 = {
+				.x		= x + conf.window_gap,
+				.y		= (int16_t)(y + bar_height + conf.window_gap),
+				.width	= (uint16_t)(master_width - 2 * conf.window_gap),
+				.height = (uint16_t)(h - 2 * conf.window_gap - bar_height),
+			};
+			rectangle_t r2 = {
+				.x		= (x + master_width),
+				.y		= (int16_t)(y + bar_height + conf.window_gap),
+				.width	= (uint16_t)(r_width - (1 * conf.window_gap)),
+				.height = (uint16_t)(h - 2 * conf.window_gap - bar_height),
+			};
+			ms->rectangle	= r1;
+			tree->rectangle = r2;
+			apply_master_layout(tree);
+		} else if (l == STACK) {
+			rectangle_t	   r = {0};
+			uint16_t	   w = m->rectangle.width;
+			uint16_t	   h = m->rectangle.height;
+			const uint16_t x = m->rectangle.x;
+			const uint16_t y = m->rectangle.y;
+			if (wm->bar && m == prim_monitor) {
+				r.x		 = x + conf.window_gap;
+				r.y		 = y + wm->bar->rectangle.height + conf.window_gap;
+				r.width	 = w - 2 * conf.window_gap - 2 * conf.border_width;
+				r.height = h - wm->bar->rectangle.height - 2 * conf.window_gap -
+						   2 * conf.border_width;
+			} else {
+				r.x		 = x + conf.window_gap;
+				r.y		 = y + conf.window_gap;
+				r.width	 = w - 2 * conf.window_gap - 2 * conf.border_width;
+				r.height = h - 2 * conf.window_gap - 2 * conf.border_width;
+			}
+			tree->rectangle = r;
+			apply_stack_layout(tree);
+		} else if (l == GRID) {
+			// todo
 		}
 	}
 }
@@ -1041,7 +1016,7 @@ static void
 arrange_trees(void)
 {
 	monitor_t *current_monitor = head_monitor;
-	while (current_monitor != NULL) {
+	while (current_monitor) {
 		apply_monitor_layout_changes(current_monitor);
 		current_monitor = current_monitor->next;
 	}
@@ -1066,8 +1041,7 @@ reload_config_wrapper()
 	assert(key_head == NULL && rule_head == NULL);
 
 	if (reload_config(&conf) != 0) {
-		_LOG_(ERROR,
-			  "Error while reloading config -> using default macros");
+		_LOG_(ERROR, "Error while reloading config -> using default macros");
 
 		conf.active_border_color  = ACTIVE_BORDER_COLOR;
 		conf.normal_border_color  = NORMAL_BORDER_COLOR;
@@ -1086,16 +1060,15 @@ reload_config_wrapper()
 		(prev_active_border_color != conf.active_border_color);
 	bool layout_changed = (conf.window_gap != prev_window_gap) ||
 						  (conf.border_width != prev_border_width);
-	bool desktop_changed =
-		(prev_virtual_desktops != conf.virtual_desktops);
+	bool desktop_changed = (prev_virtual_desktops != conf.virtual_desktops);
 
 	if (color_changed) {
 		monitor_t *current_monitor = head_monitor;
-		while (current_monitor != NULL) {
+		while (current_monitor) {
 			for (int j = 0; j < current_monitor->n_of_desktops; j++) {
 				if (!is_tree_empty(current_monitor->desktops[j]->tree)) {
-					if (change_colors(
-							current_monitor->desktops[j]->tree) != 0) {
+					if (change_colors(current_monitor->desktops[j]->tree) !=
+						0) {
 						_LOG_(ERROR,
 							  "error while reloading config for "
 							  "desktop %d",
@@ -1109,7 +1082,7 @@ reload_config_wrapper()
 
 	if (layout_changed) {
 		monitor_t *current_monitor = head_monitor;
-		while (current_monitor != NULL) {
+		while (current_monitor) {
 			apply_monitor_layout_changes(current_monitor);
 			current_monitor = current_monitor->next;
 		}
@@ -1119,7 +1092,7 @@ reload_config_wrapper()
 		_LOG_(INFO, "Reloading desktop changes is not implemented yet");
 		if (conf.virtual_desktops > prev_virtual_desktops) {
 			monitor_t *current_monitor = head_monitor;
-			while (current_monitor != NULL) {
+			while (current_monitor) {
 				current_monitor->n_of_desktops = conf.virtual_desktops;
 				desktop_t **n				   = (desktop_t **)realloc(
 					 current_monitor->desktops,
@@ -1148,14 +1121,13 @@ reload_config_wrapper()
 		} else if (conf.virtual_desktops < prev_virtual_desktops) {
 			int		   idx			   = get_focused_desktop_idx();
 			monitor_t *current_monitor = head_monitor;
-			while (current_monitor != NULL) {
-				for (int j = conf.virtual_desktops;
-					 j < prev_virtual_desktops;
+			while (current_monitor) {
+				for (int j = conf.virtual_desktops; j < prev_virtual_desktops;
 					 j++) {
 					if (idx == current_monitor->desktops[j]->id) {
 						switch_desktop_wrapper(&(arg_t){.idx = idx--});
 					}
-					if (current_monitor->desktops[j] != NULL) {
+					if (current_monitor->desktops[j]) {
 						if (!is_tree_empty(
 								current_monitor->desktops[j]->tree)) {
 							free_tree(current_monitor->desktops[j]->tree);
@@ -1207,10 +1179,8 @@ reload_config_wrapper()
 	}
 
 out:
-
-	render_tree(cur_monitor->desktops[get_focused_desktop_idx()]->tree);
+	render_tree(curr_monitor->desktops[get_focused_desktop_idx()]->tree);
 	xcb_flush(wm->connection);
-
 	return 0;
 }
 
@@ -1218,12 +1188,12 @@ int
 gap_handler(arg_t *arg)
 {
 	const int pxl			   = 5;
-	conf.window_gap			   = arg->r == GROW ? conf.window_gap + pxl
-								 : conf.window_gap - pxl <= 0 ? 0
-															  : conf.window_gap - pxl;
+	conf.window_gap			   = (arg->r == GROW) ? conf.window_gap + pxl
+								 : (conf.window_gap - pxl <= 0) ? 0
+																: conf.window_gap - pxl;
 
 	monitor_t *current_monitor = head_monitor;
-	while (current_monitor != NULL) {
+	while (current_monitor) {
 		apply_monitor_layout_changes(current_monitor);
 		current_monitor = current_monitor->next;
 	}
@@ -1232,7 +1202,7 @@ gap_handler(arg_t *arg)
 	if (idx == -1)
 		return -1;
 
-	render_tree(cur_monitor->desktops[idx]->tree);
+	render_tree(curr_monitor->desktops[idx]->tree);
 	xcb_flush(wm->connection);
 
 	return 0;
@@ -1241,37 +1211,34 @@ gap_handler(arg_t *arg)
 int
 flip_node_wrapper()
 {
-	xcb_window_t w =
-		get_window_under_cursor(wm->connection, wm->root_window);
+	xcb_window_t w = get_window_under_cursor(wm->connection, wm->root_window);
 
 	if (w == wm->root_window)
 		return 0;
 
 	/* node_t *node = find_node_by_window_id( */
-	/* 	cur_monitor->desktops[get_focused_desktop_idx()]->tree, w); */
-
-	node_t *node = get_focused_node(
-		cur_monitor->desktops[get_focused_desktop_idx()]->tree);
+	/* 	curr_monitor->desktops[get_focused_desktop_idx()]->tree, w); */
+	node_t *tree = get_foucsed_desktop_tree();
+	if (!tree)
+		return -1;
+	node_t *node = get_focused_node(tree);
 	if (node == NULL)
 		return -1;
 
 	flip_node(node);
-	return render_tree(
-		cur_monitor->desktops[get_focused_desktop_idx()]->tree);
+	return render_tree(tree);
 }
 
 int
 cycle_win_wrapper(arg_t *arg)
 {
-	direction_t d = arg->d;
-	node_t *root  = cur_monitor->desktops[get_focused_desktop_idx()]->tree;
-	node_t *f	  = get_focused_node(root);
-
-	if (root == NULL) {
+	direction_t d	 = arg->d;
+	node_t	   *root = get_foucsed_desktop_tree();
+	if (!root) {
 		return 0;
 	}
-
-	if (f == NULL) {
+	node_t *f = get_focused_node(root);
+	if (!f) {
 		_LOG_(INFO, "cannot find focused window");
 		xcb_window_t w =
 			get_window_under_cursor(wm->connection, wm->root_window);
@@ -1297,17 +1264,14 @@ int
 traverse_stack_wrapper(arg_t *arg)
 {
 	direction_t	 d = arg->d;
-	xcb_window_t w =
-		get_window_under_cursor(wm->connection, wm->root_window);
+	xcb_window_t w = get_window_under_cursor(wm->connection, wm->root_window);
 
 	if (w == wm->root_window)
 		return 0;
 
-	int i = get_focused_desktop_idx();
-	if (i == -1)
-		return i;
-
-	node_t *root = cur_monitor->desktops[i]->tree;
+	node_t *root = get_foucsed_desktop_tree();
+	if (!root)
+		return -1;
 	/* node_t *node = find_node_by_window_id(root, w); */
 
 	node_t *node = get_focused_node(root);
@@ -1318,9 +1282,9 @@ traverse_stack_wrapper(arg_t *arg)
 	}
 
 	set_focus(n, true);
-	if(has_floating_window(root))
+	if (has_floating_window(root))
 		restack();
-	
+
 	return 0;
 }
 
@@ -1329,7 +1293,7 @@ get_active_clients_size_prime()
 {
 	size_t	   t	= 0;
 	monitor_t *curr = head_monitor;
-	while (curr != NULL) {
+	while (curr) {
 		for (int i = 0; i < curr->n_of_desktops; ++i) {
 			t += curr->desktops[i]->n_count;
 		}
@@ -1354,7 +1318,7 @@ populate_client_array(node_t *root, xcb_window_t *arr, size_t *index)
 	if (root == NULL)
 		return;
 
-	if (root->client != NULL && root->client->window != XCB_NONE) {
+	if (root->client && root->client->window != XCB_NONE) {
 		arr[*index] = root->client->window;
 		(*index)++;
 	}
@@ -1375,7 +1339,6 @@ ewmh_update_client_list(void)
 	}
 	// TODO handle stacking client list --
 	// xcb_ewmh_set_client_list_stacking(...)
-
 	//  xcb_window_t active_clients[size + 1];
 	xcb_window_t *active_clients =
 		(xcb_window_t *)malloc((size + 1) * sizeof(xcb_window_t));
@@ -1384,15 +1347,14 @@ ewmh_update_client_list(void)
 	}
 	size_t	   index = 0;
 	monitor_t *curr	 = head_monitor;
-	while (curr != NULL) {
+	while (curr) {
 		for (int i = 0; i < curr->n_of_desktops; ++i) {
 			node_t *root = curr->desktops[i]->tree;
 			populate_client_array(root, active_clients, &index);
 		}
 		curr = curr->next;
 	}
-	xcb_ewmh_set_client_list(
-		wm->ewmh, wm->screen_nbr, size, active_clients);
+	xcb_ewmh_set_client_list(wm->ewmh, wm->screen_nbr, size, active_clients);
 	_LOG_(DEBUG, "set client size done");
 	free(active_clients);
 	active_clients = NULL;
@@ -1407,9 +1369,7 @@ ewmh_update_current_desktop(xcb_ewmh_connection_t *ewmh,
 		xcb_ewmh_set_current_desktop_checked(ewmh, screen_nbr, i);
 	xcb_generic_error_t *err = xcb_request_check(ewmh->connection, c);
 	if (err) {
-		_LOG_(ERROR,
-			  "Error setting number of desktops: %d\n",
-			  err->error_code);
+		_LOG_(ERROR, "Error setting number of desktops: %d", err->error_code);
 		free(err);
 		return -1;
 	}
@@ -1422,10 +1382,9 @@ get_geometry(xcb_window_t win, xcb_conn_t *conn)
 	xcb_get_geometry_cookie_t gc = xcb_get_geometry_unchecked(conn, win);
 	xcb_generic_error_t		 *err;
 	xcb_get_geometry_reply_t *gr = xcb_get_geometry_reply(conn, gc, &err);
-
 	if (err) {
 		_LOG_(ERROR,
-			  "Error getting geometry for window %u: %d\n",
+			  "Error getting geometry for window %u: %d",
 			  win,
 			  err->error_code);
 		free(err);
@@ -1433,10 +1392,9 @@ get_geometry(xcb_window_t win, xcb_conn_t *conn)
 	}
 
 	if (gr == NULL) {
-		_LOG_(ERROR, "Failed to get geometry for window %u\n", win);
+		_LOG_(ERROR, "Failed to get geometry for window %u", win);
 		return NULL;
 	}
-
 	return gr;
 }
 
@@ -1452,13 +1410,12 @@ create_client(xcb_window_t win, xcb_atom_t wtype, xcb_conn_t *conn)
 	c->border_width			   = (uint32_t)-1;
 	const uint32_t	  mask	   = XCB_CW_EVENT_MASK;
 	const uint32_t	  values[] = {CLIENT_EVENT_MASK};
-	xcb_void_cookie_t cookie   = xcb_change_window_attributes_checked(
-		  conn, c->window, mask, values);
+	xcb_void_cookie_t cookie =
+		xcb_change_window_attributes_checked(conn, c->window, mask, values);
 	xcb_generic_error_t *err = xcb_request_check(conn, cookie);
-
 	if (err) {
 		_LOG_(ERROR,
-			  "Error setting window attributes for client %u: %d\n",
+			  "Error setting window attributes for client %u: %d",
 			  c->window,
 			  err->error_code);
 		free(err);
@@ -1471,7 +1428,7 @@ create_client(xcb_window_t win, xcb_atom_t wtype, xcb_conn_t *conn)
 						   conf.normal_border_color,
 						   conf.border_width,
 						   false) != 0) {
-		_LOG_(ERROR, "Failed to change border attr for window %d\n", win);
+		_LOG_(ERROR, "Failed to change border attr for window %d", win);
 		free(c);
 		c = NULL;
 		return NULL;
@@ -1486,7 +1443,6 @@ init_desktop(void)
 	desktop_t *d = (desktop_t *)malloc(sizeof(desktop_t));
 	if (d == 0x00)
 		return NULL;
-
 	d->id		  = 0;
 	d->is_focused = false;
 	d->n_count	  = 0;
@@ -1500,7 +1456,6 @@ init_monitor(void)
 	monitor_t *m = (monitor_t *)malloc(sizeof(monitor_t));
 	if (m == 0x00)
 		return NULL;
-
 	m->id		= 0;
 	m->randr_id = XCB_NONE;
 	snprintf(m->name, sizeof(m->name), "%s", MONITOR_NAME);
@@ -1510,7 +1465,6 @@ init_monitor(void)
 	m->is_occupied = false;
 	m->is_wired	   = false;
 	m->next		   = NULL;
-
 	return m;
 }
 
@@ -1522,10 +1476,55 @@ add_monitor(monitor_t **head, monitor_t *m)
 		return;
 	}
 	monitor_t *current = *head;
-	while (current->next != NULL) {
+	while (current->next) {
 		current = current->next;
 	}
 	current->next = m;
+}
+
+static void
+remove_monitor_by_id(monitor_t **head, xcb_randr_output_t randr_id)
+{
+	if (!head || !*head) {
+		return;
+	}
+	monitor_t *curr = *head;
+	monitor_t *prev = NULL;
+	while (curr) {
+		if (curr->randr_id == randr_id) {
+			if (prev == NULL) {
+				*head = curr->next;
+			} else {
+				prev->next = curr->next;
+			}
+			_FREE_(curr);
+			return;
+		}
+		prev = curr;
+		curr = curr->next;
+	}
+}
+
+static void
+log_monitors(void)
+{
+	if (!head_monitor) {
+		_LOG_(INFO, "monitors list is empty");
+		return;
+	}
+	monitor_t *curr = head_monitor;
+	while (curr) {
+		_LOG_(INFO,
+			  "found monitor %s:%d, rectangle {.x = %d, .y = %d, .w = %d, .h = "
+			  "%d}",
+			  curr->name,
+			  curr->randr_id,
+			  curr->rectangle.x,
+			  curr->rectangle.y,
+			  curr->rectangle.width,
+			  curr->rectangle.height);
+		curr = curr->next;
+	}
 }
 
 static wm_t *
@@ -1534,13 +1533,13 @@ init_wm(void)
 	int i, default_screen;
 	wm = (wm_t *)malloc(sizeof(wm_t));
 	if (wm == NULL) {
-		_LOG_(ERROR, "Failed to malloc for window manager\n");
+		_LOG_(ERROR, "Failed to malloc for window manager");
 		return NULL;
 	}
 
 	wm->connection = xcb_connect(NULL, &default_screen);
 	if (xcb_connection_has_error(wm->connection) > 0) {
-		_LOG_(ERROR, "Error: Unable to open X connection\n");
+		_LOG_(ERROR, "Error: Unable to open X connection");
 		free(wm);
 		return NULL;
 	}
@@ -1550,7 +1549,6 @@ init_wm(void)
 	for (i = 0; i < default_screen; ++i) {
 		xcb_screen_next(&iter);
 	}
-
 	wm->screen				   = iter.data;
 	wm->root_window			   = iter.data->root;
 	wm->screen_nbr			   = default_screen;
@@ -1567,7 +1565,7 @@ init_wm(void)
 		_LOG_(ERROR,
 			  "Error registering for substructure redirection "
 			  "events on window "
-			  "%u: %d\n",
+			  "%u: %d",
 			  wm->root_window,
 			  err->error_code);
 		free(wm);
@@ -1598,7 +1596,7 @@ static monitor_t *
 get_monitor_by_randr_id(xcb_randr_output_t id)
 {
 	monitor_t *current = head_monitor;
-	while (current != NULL) {
+	while (current) {
 		if (current->randr_id == id) {
 			return current;
 		}
@@ -1611,7 +1609,7 @@ static monitor_t *
 get_monitor_by_root_id(xcb_window_t id)
 {
 	monitor_t *current = head_monitor;
-	while (current != NULL) {
+	while (current) {
 		if (current->root == id) {
 			return current;
 		}
@@ -1637,13 +1635,11 @@ get_focused_monitor()
 	int		   pointer_y = pointer_reply->root_y;
 
 	monitor_t *current	 = head_monitor;
-	while (current != NULL) {
+	while (current) {
 		if (pointer_x >= current->rectangle.x &&
-			pointer_x <
-				(current->rectangle.x + current->rectangle.width) &&
+			pointer_x < (current->rectangle.x + current->rectangle.width) &&
 			pointer_y >= current->rectangle.y &&
-			pointer_y <
-				(current->rectangle.y + current->rectangle.height)) {
+			pointer_y < (current->rectangle.y + current->rectangle.height)) {
 			free(pointer_reply);
 			return current;
 		}
@@ -1672,28 +1668,23 @@ static int
 get_connected_monitor_count_xrandr()
 {
 	xcb_randr_get_screen_resources_current_cookie_t c =
-		xcb_randr_get_screen_resources_current(wm->connection,
-											   wm->root_window);
+		xcb_randr_get_screen_resources_current(wm->connection, wm->root_window);
 	xcb_randr_get_screen_resources_current_reply_t *sres =
-		xcb_randr_get_screen_resources_current_reply(
-			wm->connection, c, NULL);
+		xcb_randr_get_screen_resources_current_reply(wm->connection, c, NULL);
 	if (sres == NULL) {
-		fprintf(stderr, "Failed to get screen resources\n");
+		fprintf(stderr, "Failed to get screen resources");
 		return -1;
 	}
-
 	int len = xcb_randr_get_screen_resources_current_outputs_length(sres);
 	xcb_randr_output_t *outputs =
 		xcb_randr_get_screen_resources_current_outputs(sres);
-
 	int monitor_count = 0;
 	for (int i = 0; i < len; i++) {
-		xcb_randr_get_output_info_cookie_t info_c =
-			xcb_randr_get_output_info(
-				wm->connection, outputs[i], XCB_CURRENT_TIME);
+		xcb_randr_get_output_info_cookie_t info_c = xcb_randr_get_output_info(
+			wm->connection, outputs[i], XCB_CURRENT_TIME);
 		xcb_randr_get_output_info_reply_t *info =
 			xcb_randr_get_output_info_reply(wm->connection, info_c, NULL);
-		if (info != NULL) {
+		if (info) {
 			if (info->connection == XCB_RANDR_CONNECTION_CONNECTED) {
 				monitor_count++;
 			}
@@ -1701,7 +1692,6 @@ get_connected_monitor_count_xrandr()
 		}
 	}
 	free(sres);
-
 	return monitor_count;
 }
 
@@ -1714,8 +1704,7 @@ get_connected_monitor_count(bool xrandr, bool xinerama)
 	} else if (xrandr == false && xinerama == true) {
 		n = get_connected_monitor_count_xinerama();
 	} else if (xrandr == true && xinerama == true) {
-		_LOG_(WARNING,
-			  "huh?... seems like both xrandr & xinerama are active");
+		_LOG_(WARNING, "huh?...");
 	} else {
 		n = 1;
 	}
@@ -1725,93 +1714,99 @@ get_connected_monitor_count(bool xrandr, bool xinerama)
 static bool
 setup_monitors_via_xrandr()
 {
-	xcb_randr_get_screen_resources_cookie_t screen_resources_c =
-		xcb_randr_get_screen_resources(wm->connection, wm->root_window);
-	xcb_randr_get_screen_resources_reply_t *screen_resources_r =
-		xcb_randr_get_screen_resources_reply(
-			wm->connection, screen_resources_c, NULL);
-	if (screen_resources_r == NULL) {
-		_LOG_(ERROR, "Failed to get screen resources\n");
+	xcb_connection_t							   *conn = wm->connection;
+	xcb_window_t									root = wm->root_window;
+	xcb_randr_get_screen_resources_current_cookie_t sc =
+		xcb_randr_get_screen_resources_current(conn, root);
+	xcb_randr_get_screen_resources_current_reply_t *sr =
+		xcb_randr_get_screen_resources_current_reply(conn, sc, NULL);
+	if (sr == NULL) {
+		_LOG_(ERROR, "failed to query screen resources");
 		return false;
 	}
-	int len =
-		xcb_randr_get_screen_resources_outputs_length(screen_resources_r);
+	const xcb_timestamp_t time = sr->config_timestamp;
+	const int len = xcb_randr_get_screen_resources_current_outputs_length(sr);
 	xcb_randr_output_t *outputs =
-		xcb_randr_get_screen_resources_outputs(screen_resources_r);
-	xcb_randr_get_output_info_cookie_t output_cookies[len];
+		xcb_randr_get_screen_resources_current_outputs(sr);
+	xcb_randr_get_output_info_cookie_t oc[len];
 	for (int i = 0; i < len; i++) {
-		output_cookies[i] = xcb_randr_get_output_info(
-			wm->connection, outputs[i], XCB_CURRENT_TIME);
+		oc[i] = xcb_randr_get_output_info(conn, outputs[i], time);
 	}
-
-	int monitor_count = 0;
+	int monitors = 0;
 	for (int i = 0; i < len; i++) {
-		xcb_randr_get_output_info_reply_t *info =
-			xcb_randr_get_output_info_reply(
-				wm->connection, output_cookies[i], NULL);
-		if (info != NULL) {
-			if (info->connection == XCB_RANDR_CONNECTION_CONNECTED) {
-				if (info->crtc != XCB_NONE) {
-					monitor_count++;
-					xcb_randr_get_crtc_info_cookie_t crtc_c =
-						xcb_randr_get_crtc_info(
-							wm->connection, info->crtc, XCB_CURRENT_TIME);
-					xcb_randr_get_crtc_info_reply_t *cir =
-						xcb_randr_get_crtc_info_reply(
-							wm->connection, crtc_c, NULL);
-					if (cir != NULL) {
-						char *name =
-							(char *)xcb_randr_get_output_info_name(info);
-						size_t name_len =
-							xcb_randr_get_output_info_name_length(info);
-
-						monitor_t *m = init_monitor();
-						if (m == NULL) {
-							_LOG_(ERROR,
-								  "Failed to allocate single monitor");
-							return false;
-						}
-						memset(m->name, 0, sizeof(m->name));
-						snprintf(m->name,
-								 sizeof(m->name),
-								 "%.*s",
-								 (int)name_len,
-								 name);
-						m->rectangle =
-							(rectangle_t){.x	  = cir->x,
-										  .y	  = cir->y,
-										  .width  = cir->width,
-										  .height = cir->height};
-						m->is_focused  = false;
-						m->is_occupied = false;
-						m->is_wired	   = false;
-						m->randr_id	   = outputs[i];
-						m->next		   = NULL;
-						add_monitor(&head_monitor, m);
-
-						_LOG_(INFO,
-							  "Monitor name = %.*s:%d, out %d Monitor "
-							  "rectangle = x = "
-							  "%d, y = %d, w = %d, h = %d\n",
-							  (int)name_len,
-							  name,
-							  m->randr_id,
-							  outputs[i],
-							  cir->x,
-							  cir->y,
-							  cir->width,
-							  cir->height);
-						free(cir);
-					}
-				}
-			}
-			free(info);
+		xcb_randr_get_output_info_reply_t *info;
+		if ((info = xcb_randr_get_output_info_reply(conn, oc[i], NULL)) ==
+			NULL) {
+			_LOG_(INFO, "could not query output info... skipping this output");
+			continue;
 		}
+		if (info->connection == XCB_RANDR_CONNECTION_DISCONNECTED) {
+			_LOG_(INFO, "output is disconnected... skipping this output");
+			_FREE_(info);
+			continue;
+		}
+		if (info->crtc == XCB_NONE) {
+			_LOG_(INFO, "output crtc is empty... skipping this output");
+			_FREE_(info);
+			continue;
+		}
+		// monitor_t *mm = get_monitor_by_randr_id(outputs[i]);
+		// if (mm) {
+		// 	_LOG_(INFO, "monitor was found... skipping this output");
+		// 	_FREE_(info);
+		// 	continue;
+		// }
+		xcb_randr_get_crtc_info_cookie_t ic;
+		xcb_randr_get_crtc_info_reply_t *crtc;
+		ic = xcb_randr_get_crtc_info(conn, info->crtc, time);
+		if ((crtc = xcb_randr_get_crtc_info_reply(conn, ic, NULL)) == NULL) {
+			_LOG_(INFO,
+				  "could not get CRTC (0x%08x)... skipping output",
+				  info->crtc);
+			_FREE_(info);
+			continue;
+		}
+		char	  *name		= (char *)xcb_randr_get_output_info_name(info);
+		size_t	   name_len = xcb_randr_get_output_info_name_length(info);
+		monitor_t *m		= init_monitor();
+		if (m == NULL) {
+			_LOG_(ERROR, "failed to allocate single monitor");
+			_FREE_(info);
+			_FREE_(crtc);
+			_FREE_(sr);
+			return false;
+		}
+		memset(m->name, 0, sizeof(m->name));
+		snprintf(m->name, sizeof(m->name), "%.*s", (int)name_len, name);
+		m->rectangle   = (rectangle_t){.x	   = crtc->x,
+									   .y	   = crtc->y,
+									   .width  = crtc->width,
+									   .height = crtc->height};
+		m->is_focused  = false;
+		m->is_occupied = false;
+		m->is_wired	   = false;
+		m->randr_id	   = outputs[i];
+		m->next		   = NULL;
+		m->desktops	   = NULL;
+		add_monitor(&head_monitor, m);
+		_LOG_(INFO,
+			  "Monitor name = %.*s:%d, out %d Monitor "
+			  "rectangle = x = "
+			  "%d, y = %d, w = %d, h = %d",
+			  (int)name_len,
+			  name,
+			  m->randr_id,
+			  outputs[i],
+			  crtc->x,
+			  crtc->y,
+			  crtc->width,
+			  crtc->height);
+		monitors++;
+		_FREE_(crtc);
+		_FREE_(info);
 	}
-
-	free(screen_resources_r);
-	_LOG_(INFO, "Number of monitors connected: %d\n", monitor_count);
-
+	_FREE_(sr);
+	_LOG_(INFO, "%d connected monitors", monitors);
 	return true;
 }
 
@@ -1821,12 +1816,11 @@ setup_monitors_via_xinerama()
 	xcb_xinerama_query_screens_cookie_t query_screens_c =
 		xcb_xinerama_query_screens(wm->connection);
 	xcb_xinerama_query_screens_reply_t *query_screens_r =
-		xcb_xinerama_query_screens_reply(
-			wm->connection, query_screens_c, NULL);
+		xcb_xinerama_query_screens_reply(wm->connection, query_screens_c, NULL);
 	xcb_xinerama_screen_info_t *xinerama_screen_i =
 		xcb_xinerama_query_screens_screen_info(query_screens_r);
 	if (query_screens_r == NULL) {
-		_LOG_(ERROR, "Failed to query Xinerama screens\n");
+		_LOG_(ERROR, "Failed to query Xinerama screens");
 		return false;
 	}
 	int n = xcb_xinerama_query_screens_screen_info_length(query_screens_r);
@@ -1837,7 +1831,7 @@ setup_monitors_via_xinerama()
 			(rectangle_t){info.x_org, info.y_org, info.width, info.height};
 		monitor_t *m = init_monitor();
 		if (m == NULL) {
-			_LOG_(ERROR, "Failed to allocate single monitor\n");
+			_LOG_(ERROR, "Failed to allocate single monitor");
 			free(query_screens_r);
 			return false;
 		}
@@ -1859,11 +1853,11 @@ static void
 free_monitors(void)
 {
 	monitor_t *current = head_monitor;
-	while (current != NULL) {
+	while (current) {
 		monitor_t *next = current->next;
 		for (int j = 0; j < current->n_of_desktops; j++) {
-			if (current->desktops[j] != NULL) {
-				if (current->desktops[j]->tree != NULL) {
+			if (current->desktops[j]) {
+				if (current->desktops[j]->tree) {
 					free_tree(current->desktops[j]->tree);
 				}
 				free(current->desktops[j]);
@@ -1881,30 +1875,25 @@ ewmh_update_desktop_viewport(void)
 {
 	uint32_t   desktops_count  = 0;
 	monitor_t *current_monitor = head_monitor;
-	while (current_monitor != NULL) {
+	while (current_monitor) {
 		desktops_count += current_monitor->n_of_desktops;
 		current_monitor = current_monitor->next;
 	}
-
 	if (desktops_count == 0) {
 		xcb_ewmh_set_desktop_viewport(wm->ewmh, wm->screen_nbr, 0, NULL);
 		return;
 	}
-
 	xcb_ewmh_coordinates_t coords[desktops_count];
 	uint16_t			   desktop = 0;
 	current_monitor				   = head_monitor;
-	while (current_monitor != NULL) {
+	while (current_monitor) {
 		for (int j = 0; j < current_monitor->n_of_desktops; j++) {
-			coords[desktop++] =
-				(xcb_ewmh_coordinates_t){current_monitor->rectangle.x,
-										 current_monitor->rectangle.y};
+			coords[desktop++] = (xcb_ewmh_coordinates_t){
+				current_monitor->rectangle.x, current_monitor->rectangle.y};
 		}
 		current_monitor = current_monitor->next;
 	}
-
-	xcb_ewmh_set_desktop_viewport(
-		wm->ewmh, wm->screen_nbr, desktop, coords);
+	xcb_ewmh_set_desktop_viewport(wm->ewmh, wm->screen_nbr, desktop, coords);
 }
 
 static bool
@@ -1930,7 +1919,7 @@ setup_monitors(void)
 			xcb_xinerama_is_active(wm->connection);
 		xcb_xinerama_is_active_reply_t *xis_active =
 			xcb_xinerama_is_active_reply(wm->connection, xc, NULL);
-		if (xis_active != NULL) {
+		if (xis_active) {
 			xinerama_is_active = xis_active->state;
 			free(xis_active);
 			using_xrandr   = false;
@@ -1943,19 +1932,16 @@ setup_monitors(void)
 	int n = get_connected_monitor_count(using_xrandr, using_xinerama);
 
 	if (!using_xrandr && !using_xinerama && n == 1) {
-		_LOG_(ERROR,
-			  "Neither Xrandr nor Xinerama extensions are available\n");
+		_LOG_(ERROR, "Neither Xrandr nor Xinerama extensions are available");
 		use_global_screen = true;
 	}
 
 	if (use_global_screen) {
-		rectangle_t r = (rectangle_t){0,
-									  0,
-									  wm->screen->width_in_pixels,
-									  wm->screen->height_in_pixels};
-		monitor_t  *m = init_monitor();
+		rectangle_t r = (rectangle_t){
+			0, 0, wm->screen->width_in_pixels, wm->screen->height_in_pixels};
+		monitor_t *m = init_monitor();
 		if (m == NULL) {
-			_LOG_(ERROR, "Failed to allocate single monitor\n");
+			_LOG_(ERROR, "Failed to allocate single monitor");
 			return false;
 		}
 		memset(m->name, 0, sizeof(m->name));
@@ -1967,7 +1953,7 @@ setup_monitors(void)
 		m->is_wired	   = false;
 		m->randr_id	   = 0;
 		add_monitor(&head_monitor, m);
-		prim_monitor = cur_monitor = m;
+		prim_monitor = curr_monitor = m;
 		goto out;
 	}
 
@@ -1975,25 +1961,24 @@ setup_monitors(void)
 	if (using_xrandr && !using_xinerama) {
 		setup_success = setup_monitors_via_xrandr();
 		if (setup_success) {
-			_LOG_(INFO, "Monitors successfully set up using Xrandr\n");
+			_LOG_(INFO, "Monitors successfully set up using Xrandr");
 		}
 	} else if (using_xinerama && !using_xrandr) {
 		setup_success = setup_monitors_via_xinerama();
 		if (setup_success) {
-			_LOG_(INFO, "Monitors successfully set up using Xinerama\n");
+			_LOG_(INFO, "Monitors successfully set up using Xinerama");
 		}
 	}
 
 	if (!setup_success) {
-		_LOG_(ERROR,
-			  "fialed to setup monitors, defaulting to global screen");
+		_LOG_(ERROR, "fialed to setup monitors, defaulting to global screen");
 
 		return false;
 	}
 
 	// set monitors roots
 	// for (int i = 0; i < wm->n_of_monitors; i++) {
-	// 	if (wm->monitors[i] != NULL) {
+	// 	if (wm->monitors[i] ) {
 	// 		uint32_t values[]	  = {XCB_EVENT_MASK_ENTER_WINDOW};
 	// 		wm->monitors[i]->root = xcb_generate_id(wm->connection);
 	// 		xcb_create_window(wm->connection,
@@ -2013,7 +1998,7 @@ setup_monitors(void)
 	// 		xcb_change_window_attributes(
 	// 			wm->connection, wm->monitors[i]->root, mask, values);
 	// 		_LOG_(INFO,
-	// 			  "succseffuly created root %d for monitor %s\n",
+	// 			  "succseffuly created root %d for monitor %s",
 	// 			  wm->monitors[i]->root,
 	// 			  wm->monitors[i]->name);
 	// 		// show_window(wm->monitors[i]->root);
@@ -2036,14 +2021,13 @@ setup_monitors(void)
 	xcb_randr_get_output_primary_reply_t *primary_output_reply =
 		xcb_randr_get_output_primary_reply(wm->connection, ccc, NULL);
 
-	if (primary_output_reply != NULL) {
-		monitor_t *mm =
-			get_monitor_by_randr_id(primary_output_reply->output);
-		if (mm != NULL) {
+	if (primary_output_reply) {
+		monitor_t *mm = get_monitor_by_randr_id(primary_output_reply->output);
+		if (mm) {
 			mm->is_primary = true;
-			prim_monitor = cur_monitor = mm;
+			prim_monitor = curr_monitor = mm;
 		} else {
-			prim_monitor = cur_monitor = head_monitor;
+			prim_monitor = curr_monitor = head_monitor;
 		}
 	} else {
 		_LOG_(INFO, "no monitor is found");
@@ -2067,11 +2051,229 @@ out:
 	return true;
 }
 
+bool
+handle_added_monitor(xcb_randr_get_output_info_reply_t *info,
+					 xcb_randr_output_t					id)
+{
+	xcb_randr_get_crtc_info_cookie_t crtc_c =
+		xcb_randr_get_crtc_info(wm->connection, info->crtc, XCB_CURRENT_TIME);
+	xcb_randr_get_crtc_info_reply_t *crtc =
+		xcb_randr_get_crtc_info_reply(wm->connection, crtc_c, NULL);
+	if (!crtc) {
+		_LOG_(ERROR, "failed to query crtc for %d", id);
+		return false;
+	}
+	char	  *name		= (char *)xcb_randr_get_output_info_name(info);
+	size_t	   name_len = xcb_randr_get_output_info_name_length(info);
+	monitor_t *m		= init_monitor();
+	if (!m) {
+		_LOG_(ERROR, "failed to allocate single monitor for output %d", id);
+		_FREE_(crtc);
+		return false;
+	}
+	memset(m->name, 0, sizeof(m->name));
+	snprintf(m->name, sizeof(m->name), "%.*s", (int)name_len, name);
+	m->rectangle   = (rectangle_t){.x	   = crtc->x,
+								   .y	   = crtc->y,
+								   .width  = crtc->width,
+								   .height = crtc->height};
+	m->is_focused  = false;
+	m->is_occupied = false;
+	m->is_wired	   = false;
+	m->randr_id	   = id;
+	m->next		   = NULL;
+	m->desktops	   = NULL;
+	add_monitor(&head_monitor, m);
+	_LOG_(INFO,
+		  "monitor name = %.*s:%d, out %d Monitor "
+		  "rectangle = x = "
+		  "%d, y = %d, w = %d, h = %d was ADDED",
+		  (int)name_len,
+		  name,
+		  m->randr_id,
+		  id,
+		  crtc->x,
+		  crtc->y,
+		  crtc->width,
+		  crtc->height);
+	_FREE_(crtc);
+	return true;
+}
+
+void
+destroy_monitor(monitor_t *m)
+{
+	for (int i = 0; i < m->n_of_desktops; i++) {
+		if (m->desktops[i]) {
+			if (m->desktops[i]->tree) {
+				free_tree(m->desktops[i]->tree);
+			}
+			_FREE_(m->desktops[i]);
+		}
+	}
+	_FREE_(m->desktops);
+	xcb_randr_output_t id = m->randr_id;
+	remove_monitor_by_id(&head_monitor, m->randr_id);
+	assert(!get_monitor_by_randr_id(id));
+}
+
+static bool
+is_monitor_layout_changed(xcb_randr_get_output_info_reply_t *info,
+						  rectangle_t						*r,
+						  rectangle_t						*r_out)
+{
+	xcb_randr_get_crtc_info_cookie_t crtc_c =
+		xcb_randr_get_crtc_info(wm->connection, info->crtc, XCB_CURRENT_TIME);
+	xcb_randr_get_crtc_info_reply_t *crtc =
+		xcb_randr_get_crtc_info_reply(wm->connection, crtc_c, NULL);
+	if (!crtc) {
+		_LOG_(ERROR, "failed to query crtc for");
+		return false;
+	}
+	*r_out = (rectangle_t){.x	   = crtc->x,
+						   .y	   = crtc->y,
+						   .width  = crtc->width,
+						   .height = crtc->height};
+	_FREE_(crtc);
+	return (r->x != r_out->x || r->y != r_out->y || r->width != r_out->width ||
+			r->height != r_out->height);
+}
+
+static void
+update_monitors(uint32_t *changes)
+{
+	monitor_t		 *dl   = NULL; /* a list of monitors to remove*/
+	xcb_connection_t *conn = wm->connection;
+	xcb_randr_get_screen_resources_current_cookie_t rc		  = {0};
+	xcb_randr_get_screen_resources_current_reply_t *resources = NULL;
+	rc		  = xcb_randr_get_screen_resources_current(conn, wm->root_window);
+	resources = xcb_randr_get_screen_resources_current_reply(conn, rc, NULL);
+
+	if (!resources) {
+		_LOG_(ERROR, "failed to get screen resources");
+		return;
+	}
+
+	int len = xcb_randr_get_screen_resources_current_outputs_length(resources);
+	xcb_randr_output_t *outputs =
+		xcb_randr_get_screen_resources_current_outputs(resources);
+	int monitor_count = 0;
+	for (int i = 0; i < len; i++) {
+		xcb_randr_get_output_info_cookie_t info_cookie =
+			xcb_randr_get_output_info(conn, outputs[i], XCB_CURRENT_TIME);
+		xcb_randr_get_output_info_reply_t *info =
+			xcb_randr_get_output_info_reply(conn, info_cookie, NULL);
+		if (!info)
+			continue;
+		if (info->connection == XCB_RANDR_CONNECTION_DISCONNECTED) {
+			/* this output might have been connnected before, if so, add it to
+			 * the list so we can remove it later */
+			monitor_t *exist = get_monitor_by_randr_id(outputs[i]);
+			if (!exist) {
+				free(info);
+				continue;
+			}
+			/* append to the list */
+			exist->next = dl;
+			dl			= exist;
+		}
+		if (info->crtc == XCB_NONE) {
+			free(info);
+			continue;
+		}
+		if (info->connection == XCB_RANDR_CONNECTION_CONNECTED) {
+			/* if this output is connected;
+			 * 1- it could be new.
+			 * 2- it could be old but its resolution or position have
+			 * changed.
+			 */
+			monitor_t *exist = get_monitor_by_randr_id(outputs[i]);
+			if (!exist) {
+				/* this is a new monitor */
+				if (!handle_added_monitor(info, outputs[i])) {
+					_LOG_(ERROR, "failed to add new output %d", outputs[i]);
+					_FREE_(info);
+					continue;
+				}
+				monitor_count++;
+				*changes &= ~_NONE;
+				*changes |= CONNECTED;
+			} else {
+				/* this monitor exists, check whether or not its layout was
+				 * changed */
+				rectangle_t r = {0};
+				if (is_monitor_layout_changed(info, &exist->rectangle, &r)) {
+					exist->rectangle = r;
+					*changes &= ~_NONE;
+					*changes |= LAYOUT;
+				}
+			}
+		}
+	}
+	/* check for disconnected monitors */
+	if (dl) {
+		/* windows from disconnected monitors are supposed to be moved
+		 * to any other available monitor. BUT, this require some
+		 * extra work to merge trees/desktops without triggering other inner
+		 * calls that may cause craches */
+
+		/* for now, a disconneced monitor is freed entirely, this includes its
+		 * desktops and trees, things will be lost as a result */
+		while (dl) {
+			monitor_t *to_remove = dl;
+			dl					 = dl->next;
+			destroy_monitor(to_remove);
+		}
+		*changes &= ~_NONE;
+		*changes |= DISCONNECTED;
+	}
+	_LOG_(INFO, "%d newly connected monitor", monitor_count);
+}
+
+static void
+handle_monitor_changes(void)
+{
+	/* there are 3 scenarios we're interested in
+	 * 1- a new monitor is connected, we need to add it to the monitor
+	 * list and assign desktops to it.
+	 * 2- an exisitng monitor was
+	 * disconnected, we need to merge its desktops with the primary monitor
+	 * then remove it and free its desktops and trees.
+	 * 3- a resolution or oreintation was changed for an existing
+	 * monitor, we need to recaluclate the rectangle for it and resize its
+	 * trees
+	 */
+	if (using_xinerama) {
+		return;
+	}
+	uint32_t m_change = _NONE;
+	update_monitors(&m_change);
+	if (m_change & _NONE) {
+		_LOG_(INFO, "no monitor changes was found");
+		return;
+	}
+	if (m_change & CONNECTED) {
+		_LOG_(INFO, "a monitor was connected");
+		setup_desktops();
+	} else if (m_change & DISCONNECTED) {
+		_LOG_(INFO, "a monitor was disconnected");
+		/* nothing to do here. in future i may merge diconnected monitor's
+		 * desktops here in here */
+		curr_monitor = prim_monitor = head_monitor;
+	} else if (m_change & LAYOUT) {
+		_LOG_(INFO, "a monitor's layout was changed");
+		arrange_trees();
+		render_trees();
+	}
+	log_monitors();
+	// TODO: update ewmh
+}
+
 monitor_t *
 get_monitor_from_desktop(desktop_t *desktop)
 {
 	monitor_t *current_monitor = head_monitor;
-	while (current_monitor != NULL) {
+	while (current_monitor) {
 		for (int j = 0; j < current_monitor->n_of_desktops; j++) {
 			if (current_monitor->desktops[j] == desktop) {
 				return current_monitor;
@@ -2085,27 +2287,34 @@ get_monitor_from_desktop(desktop_t *desktop)
 static bool
 setup_desktops(void)
 {
-	monitor_t *current_monitor = head_monitor;
-	while (current_monitor != NULL) {
-		current_monitor->n_of_desktops = conf.virtual_desktops;
-		desktop_t **desktops		   = (desktop_t **)malloc(
-			  sizeof(desktop_t *) * current_monitor->n_of_desktops);
+	monitor_t *curr = head_monitor;
+	while (curr) {
+		if (curr && curr->desktops) {
+			_LOG_(INFO,
+				  "monitor %s already has desktops... skipping",
+				  curr->name);
+			curr = curr->next;
+			continue;
+		}
+		curr->n_of_desktops = conf.virtual_desktops;
+		desktop_t **desktops =
+			(desktop_t **)malloc(sizeof(desktop_t *) * curr->n_of_desktops);
 		if (desktops == NULL) {
-			_LOG_(ERROR, "Failed to malloc desktops\n");
+			_LOG_(ERROR, "failed to malloc desktops");
 			return false;
 		}
-		current_monitor->desktops = desktops;
-		for (int j = 0; j < current_monitor->n_of_desktops; j++) {
+		curr->desktops = desktops;
+		for (int j = 0; j < curr->n_of_desktops; j++) {
 			desktop_t *d  = init_desktop();
 			d->id		  = (uint8_t)j;
 			d->is_focused = (j == 0);
 			d->layout	  = DEFAULT;
 			snprintf(d->name, sizeof(d->name), "%d", j + 1);
-			current_monitor->desktops[j] = d;
+			curr->desktops[j] = d;
 		}
-		current_monitor = current_monitor->next;
+		_LOG_(INFO, "successfuly assigned desktops for monitor %s", curr->name);
+		curr = curr->next;
 	}
-
 	return true;
 }
 
@@ -2113,21 +2322,17 @@ static int
 ewmh_update_number_of_desktops(void)
 {
 	uint32_t desktops_count	 = 0;
-
 	// for (int i = 0; i < wm->n_of_monitors; i++) {
-	// 	if (wm->monitors[i] != NULL) {
+	// 	if (wm->monitors[i] ) {
 	// 		desktops_count += wm->monitors[i]->n_of_desktops;
 	// 	}
 	// }
 	desktops_count			 = prim_monitor->n_of_desktops;
 	xcb_void_cookie_t cookie = xcb_ewmh_set_number_of_desktops_checked(
 		wm->ewmh, wm->screen_nbr, desktops_count);
-	xcb_generic_error_t *err =
-		xcb_request_check(wm->ewmh->connection, cookie);
+	xcb_generic_error_t *err = xcb_request_check(wm->ewmh->connection, cookie);
 	if (err) {
-		_LOG_(ERROR,
-			  "Error setting number of desktops: %d\n",
-			  err->error_code);
+		_LOG_(ERROR, "Error setting number of desktops: %d", err->error_code);
 		free(err);
 		return -1;
 	}
@@ -2174,9 +2379,7 @@ setup_ewmh(void)
 		  wm->ewmh, wm->screen_nbr, LEN(net_atoms), net_atoms);
 	xcb_generic_error_t *err = xcb_request_check(wm->ewmh->connection, c);
 	if (err) {
-		_LOG_(ERROR,
-			  "Error setting supported ewmh masks: %d\n",
-			  err->error_code);
+		_LOG_(ERROR, "error setting supported ewmh masks: %d", err->error_code);
 		free(err);
 		return false;
 	}
@@ -2198,8 +2401,8 @@ setup_ewmh(void)
 		return false;
 	}
 
-	if (ewmh_update_current_desktop(
-			wm->ewmh, wm->screen_nbr, (uint32_t)di) != 0) {
+	if (ewmh_update_current_desktop(wm->ewmh, wm->screen_nbr, (uint32_t)di) !=
+		0) {
 		return false;
 	}
 
@@ -2247,13 +2450,13 @@ resize_window(xcb_window_t win, uint16_t width, uint16_t height)
 
 	const uint32_t	  values[] = {width, height};
 
-	xcb_void_cookie_t cookie   = xcb_configure_window_checked(
-		  wm->connection, win, XCB_RESIZE, values);
+	xcb_void_cookie_t cookie =
+		xcb_configure_window_checked(wm->connection, win, XCB_RESIZE, values);
 	xcb_generic_error_t *err = xcb_request_check(wm->connection, cookie);
 
 	if (err) {
 		_LOG_(ERROR,
-			  "Error resizing window (ID %u): %s",
+			  "error resizing window (ID %u): %s",
 			  win,
 			  strerror(err->error_code));
 		free(err);
@@ -2271,15 +2474,12 @@ move_window(xcb_window_t win, int16_t x, int16_t y)
 	}
 
 	const uint32_t	  values[] = {x, y};
-	xcb_void_cookie_t cookie   = xcb_configure_window_checked(
-		  wm->connection, win, XCB_MOVE, values);
+	xcb_void_cookie_t cookie =
+		xcb_configure_window_checked(wm->connection, win, XCB_MOVE, values);
 	xcb_generic_error_t *err = xcb_request_check(wm->connection, cookie);
 
 	if (err) {
-		_LOG_(ERROR,
-			  "Error moving window (ID %u): %d",
-			  win,
-			  err->error_code);
+		_LOG_(ERROR, "error moving window (ID %u): %d", win, err->error_code);
 		free(err);
 		return -1;
 	}
@@ -2306,8 +2506,7 @@ fullscreen_focus(xcb_window_t win)
 		return -1;
 	}
 
-	if (set_input_focus(wm->connection, input, win, XCB_CURRENT_TIME) !=
-		0) {
+	if (set_input_focus(wm->connection, input, win, XCB_CURRENT_TIME) != 0) {
 		_LOG_(ERROR, "cannot set input focus");
 		return -1;
 	}
@@ -2339,8 +2538,8 @@ win_focus(xcb_window_t win, bool set_focus)
 	}
 
 	if (set_focus) {
-		if (set_input_focus(
-				wm->connection, input, win, XCB_CURRENT_TIME) != 0) {
+		if (set_input_focus(wm->connection, input, win, XCB_CURRENT_TIME) !=
+			0) {
 			_LOG_(ERROR, "cannot set input focus");
 			return -1;
 		}
@@ -2354,8 +2553,8 @@ static void
 hide_bar(xcb_window_t win)
 {
 	xcb_void_cookie_t	 cookie = xcb_unmap_window(wm->connection, win);
-	xcb_generic_error_t *err = xcb_request_check(wm->connection, cookie);
-	if (err != NULL) {
+	xcb_generic_error_t *err	= xcb_request_check(wm->connection, cookie);
+	if (err) {
 		_LOG_(ERROR,
 			  "in unmapping window %d: error code %d",
 			  win,
@@ -2413,9 +2612,9 @@ change_window_attr(xcb_conn_t  *conn,
 	xcb_void_cookie_t attr_cookie =
 		xcb_change_window_attributes_checked(conn, win, attr, val);
 	xcb_generic_error_t *err = xcb_request_check(conn, attr_cookie);
-	if (err != NULL) {
+	if (err) {
 		_LOG_(ERROR,
-			  "Failed to change window attributes: error code %d",
+			  "failed to change window attributes: error code %d",
 			  err->error_code);
 		free(err);
 		return -1;
@@ -2432,9 +2631,9 @@ configure_window(xcb_conn_t	 *conn,
 	xcb_void_cookie_t config_cookie =
 		xcb_configure_window_checked(conn, win, attr, val);
 	xcb_generic_error_t *err = xcb_request_check(conn, config_cookie);
-	if (err != NULL) {
+	if (err) {
 		_LOG_(ERROR,
-			  "Failed to configure window : error code %d",
+			  "failed to configure window : error code %d",
 			  err->error_code);
 		free(err);
 		return -1;
@@ -2451,9 +2650,9 @@ set_input_focus(xcb_conn_t	   *conn,
 	xcb_void_cookie_t focus_cookie =
 		xcb_set_input_focus_checked(conn, revert_to, win, time);
 	xcb_generic_error_t *err = xcb_request_check(conn, focus_cookie);
-	if (err != NULL) {
+	if (err) {
 		_LOG_(ERROR,
-			  "Failed to set input focus : error code %d",
+			  "failed to set input focus : error code %d",
 			  err->error_code);
 		free(err);
 		return -1;
@@ -2474,12 +2673,10 @@ tile(node_t *node)
 	const uint16_t height = IS_FLOATING(node->client)
 								? node->floating_rectangle.height
 								: node->rectangle.height;
-	const int16_t  x	  = IS_FLOATING(node->client)
-								? node->floating_rectangle.x
-								: node->rectangle.x;
-	const int16_t  y	  = IS_FLOATING(node->client)
-								? node->floating_rectangle.y
-								: node->rectangle.y;
+	const int16_t  x = IS_FLOATING(node->client) ? node->floating_rectangle.x
+												 : node->rectangle.x;
+	const int16_t  y = IS_FLOATING(node->client) ? node->floating_rectangle.y
+												 : node->rectangle.y;
 
 	if (resize_window(node->client->window, width, height) != 0 ||
 		move_window(node->client->window, x, y) != 0) {
@@ -2489,7 +2686,7 @@ tile(node_t *node)
 	xcb_void_cookie_t cookie =
 		xcb_map_window_checked(wm->connection, node->client->window);
 	xcb_generic_error_t *err = xcb_request_check(wm->connection, cookie);
-	if (err != NULL) {
+	if (err) {
 		_LOG_(ERROR,
 			  "in mapping window %d: error code %d",
 			  node->client->window,
@@ -2508,11 +2705,10 @@ supports_protocol(xcb_window_t win, xcb_atom_t atom, xcb_conn_t *conn)
 	xcb_get_property_cookie_t		   cookie = {0};
 	xcb_icccm_get_wm_protocols_reply_t protocols;
 	bool							   result = false;
-	xcb_atom_t WM_PROTOCOLS = get_atom("WM_PROTOCOLS", conn);
+	xcb_atom_t WM_PROTOCOLS					  = get_atom("WM_PROTOCOLS", conn);
 
 	cookie = xcb_icccm_get_wm_protocols(conn, win, WM_PROTOCOLS);
-	if (xcb_icccm_get_wm_protocols_reply(conn, cookie, &protocols, NULL) !=
-		1) {
+	if (xcb_icccm_get_wm_protocols_reply(conn, cookie, &protocols, NULL) != 1) {
 		return false;
 	}
 
@@ -2535,18 +2731,15 @@ display_client(rectangle_t r, xcb_window_t win)
 	int16_t	 x		= r.x;
 	int16_t	 y		= r.y;
 
-	if (resize_window(win, width, height) != 0 ||
-		move_window(win, x, y) != 0) {
+	if (resize_window(win, width, height) != 0 || move_window(win, x, y) != 0) {
 		return -1;
 	}
 
-	xcb_void_cookie_t cookie = xcb_map_window_checked(wm->connection, win);
-	xcb_generic_error_t *err = xcb_request_check(wm->connection, cookie);
-	if (err != NULL) {
-		_LOG_(ERROR,
-			  "in mapping window %d: error code %d",
-			  win,
-			  err->error_code);
+	xcb_void_cookie_t	 cookie = xcb_map_window_checked(wm->connection, win);
+	xcb_generic_error_t *err	= xcb_request_check(wm->connection, cookie);
+	if (err) {
+		_LOG_(
+			ERROR, "in mapping window %d: error code %d", win, err->error_code);
 		_FREE_(err);
 		return -1;
 	}
@@ -2563,7 +2756,7 @@ get_cursor_axis(xcb_conn_t *conn, xcb_window_t win)
 		xcb_query_pointer_reply(conn, p_cookie, NULL);
 
 	if (p_reply == NULL) {
-		_LOG_(ERROR, "Failed to query pointer position\n");
+		_LOG_(ERROR, "failed to query pointer position");
 		return -1;
 	}
 
@@ -2581,7 +2774,7 @@ get_window_under_cursor(xcb_conn_t *conn, xcb_window_t win)
 		xcb_query_pointer_reply(conn, p_cookie, NULL);
 
 	if (p_reply == NULL) {
-		_LOG_(ERROR, "Failed to query pointer position\n");
+		_LOG_(ERROR, "failed to query pointer position");
 		return XCB_NONE;
 	}
 
@@ -2614,7 +2807,7 @@ get_keysym(xcb_keycode_t keycode, xcb_connection_t *conn)
 	xcb_key_symbols_t *keysyms = xcb_key_symbols_alloc(conn);
 	xcb_keysym_t	   keysym  = 0;
 
-	if (keysyms != NULL) {
+	if (keysyms) {
 		keysym = xcb_key_symbols_get_keysym(keysyms, keycode, 0);
 		xcb_key_symbols_free(keysyms);
 	}
@@ -2625,18 +2818,18 @@ get_keysym(xcb_keycode_t keycode, xcb_connection_t *conn)
 void
 window_grab_buttons(xcb_window_t win)
 {
-#define _GRAB_BUTTON_(button)                                             \
-	do {                                                                  \
-		xcb_grab_button_checked(wm->connection,                           \
-								false,                                    \
-								win,                                      \
-								XCB_EVENT_MASK_BUTTON_PRESS,              \
-								XCB_GRAB_MODE_ASYNC,                      \
-								XCB_GRAB_MODE_ASYNC,                      \
-								wm->root_window,                          \
-								XCB_NONE,                                 \
-								button,                                   \
-								XCB_MOD_MASK_ANY);                        \
+#define _GRAB_BUTTON_(button)                                                  \
+	do {                                                                       \
+		xcb_grab_button_checked(wm->connection,                                \
+								false,                                         \
+								win,                                           \
+								XCB_EVENT_MASK_BUTTON_PRESS,                   \
+								XCB_GRAB_MODE_ASYNC,                           \
+								XCB_GRAB_MODE_ASYNC,                           \
+								wm->root_window,                               \
+								XCB_NONE,                                      \
+								button,                                        \
+								XCB_MOD_MASK_ANY);                             \
 	} while (0)
 	_GRAB_BUTTON_(XCB_BUTTON_INDEX_1);
 	_GRAB_BUTTON_(XCB_BUTTON_INDEX_2);
@@ -2651,7 +2844,7 @@ window_ungrab_buttons(xcb_window_t win)
 		wm->connection, XCB_BUTTON_INDEX_ANY, win, XCB_MOD_MASK_ANY);
 
 	xcb_generic_error_t *err = xcb_request_check(wm->connection, cookie);
-	if (err != NULL) {
+	if (err) {
 		_LOG_(ERROR,
 			  "in ungrab buttons for window %d: error code %d",
 			  win,
@@ -2667,7 +2860,7 @@ ungrab_buttons_for_all(node_t *n)
 	if (n == NULL)
 		return;
 
-	bool flag = n->node_type != INTERNAL_NODE && n->client != NULL;
+	bool flag = n->node_type != INTERNAL_NODE && n->client;
 
 	if (flag) {
 		xcb_ungrab_button(wm->connection,
@@ -2684,19 +2877,18 @@ void
 grab_pointer(xcb_window_t win, bool wants_events)
 {
 	xcb_grab_pointer_reply_t *reply;
-	xcb_grab_pointer_cookie_t cookie =
-		xcb_grab_pointer(wm->connection,
-						 wants_events,
-						 win,
-						 XCB_NONE,
-						 XCB_GRAB_MODE_SYNC,
-						 XCB_GRAB_MODE_ASYNC,
-						 XCB_NONE,
-						 XCB_NONE,
-						 XCB_CURRENT_TIME);
+	xcb_grab_pointer_cookie_t cookie = xcb_grab_pointer(wm->connection,
+														wants_events,
+														win,
+														XCB_NONE,
+														XCB_GRAB_MODE_SYNC,
+														XCB_GRAB_MODE_ASYNC,
+														XCB_NONE,
+														XCB_NONE,
+														XCB_CURRENT_TIME);
 	if ((reply = xcb_grab_pointer_reply(wm->connection, cookie, NULL))) {
 		if (reply->status != XCB_GRAB_STATUS_SUCCESS)
-			_LOG_(WARNING, "cannot grab the pointer\n");
+			_LOG_(WARNING, "cannot grab the pointer");
 	}
 	_FREE_(reply);
 }
@@ -2706,6 +2898,7 @@ ungrab_pointer(void)
 {
 	xcb_ungrab_pointer(wm->connection, XCB_CURRENT_TIME);
 }
+
 static int
 grab_keys(xcb_conn_t *conn, xcb_window_t win)
 {
@@ -2713,10 +2906,10 @@ grab_keys(xcb_conn_t *conn, xcb_window_t win)
 		return -1;
 	}
 
-	if (key_head != NULL) {
-		_LOG_(INFO, "----grabbing conf keys------\n");
+	if (key_head) {
+		_LOG_(INFO, "----grabbing conf keys------");
 		conf_key_t *current = key_head;
-		while (current != NULL) {
+		while (current) {
 			xcb_keycode_t *key = get_keycode(current->keysym, conn);
 			if (key == NULL)
 				return -1;
@@ -2730,8 +2923,8 @@ grab_keys(xcb_conn_t *conn, xcb_window_t win)
 									 XCB_GRAB_MODE_ASYNC);
 			_FREE_(key);
 			xcb_generic_error_t *err = xcb_request_check(conn, cookie);
-			if (err != NULL) {
-				_LOG_(ERROR, "error grabbing key %d\n", err->error_code);
+			if (err) {
+				_LOG_(ERROR, "error grabbing key %d", err->error_code);
 				_FREE_(err);
 				return -1;
 			}
@@ -2741,25 +2934,24 @@ grab_keys(xcb_conn_t *conn, xcb_window_t win)
 		return 0;
 	}
 
-	_LOG_(INFO, "----grabbing default keys------\n");
+	_LOG_(INFO, "----grabbing default keys------");
 	const size_t n = sizeof(keys_) / sizeof(keys_[0]);
 
 	for (size_t i = n; i--;) {
 		xcb_keycode_t *key = get_keycode(keys_[i].keysym, conn);
 		if (key == NULL)
 			return -1;
-		xcb_void_cookie_t cookie =
-			xcb_grab_key_checked(conn,
-								 1,
-								 win,
-								 (uint16_t)keys_[i].mod,
-								 *key,
-								 XCB_GRAB_MODE_ASYNC,
-								 XCB_GRAB_MODE_ASYNC);
+		xcb_void_cookie_t cookie = xcb_grab_key_checked(conn,
+														1,
+														win,
+														(uint16_t)keys_[i].mod,
+														*key,
+														XCB_GRAB_MODE_ASYNC,
+														XCB_GRAB_MODE_ASYNC);
 		_FREE_(key);
 		xcb_generic_error_t *err = xcb_request_check(conn, cookie);
-		if (err != NULL) {
-			_LOG_(ERROR, "error grabbing key %d\n", err->error_code);
+		if (err) {
+			_LOG_(ERROR, "error grabbing key %d", err->error_code);
 			_FREE_(err);
 			return -1;
 		}
@@ -2803,8 +2995,8 @@ send_client_message(xcb_window_t win,
 		  conn, false, win, XCB_EVENT_MASK_NO_EVENT, (char *)e);
 
 	xcb_generic_error_t *err = xcb_request_check(conn, c);
-	if (err != NULL) {
-		_LOG_(ERROR, "error sending event: %d\n", err->error_code);
+	if (err) {
+		_LOG_(ERROR, "error sending event: %d", err->error_code);
 		_FREE_(e);
 		_FREE_(err);
 		return -1;
@@ -2818,8 +3010,7 @@ send_client_message(xcb_window_t win,
 int
 close_or_kill_wrapper()
 {
-	xcb_window_t win =
-		get_window_under_cursor(wm->connection, wm->root_window);
+	xcb_window_t win = get_window_under_cursor(wm->connection, wm->root_window);
 	if (!window_exists(wm->connection, win))
 		return 0;
 	return close_or_kill(win);
@@ -2830,17 +3021,16 @@ close_or_kill(xcb_window_t win)
 {
 	xcb_atom_t wm_delete = get_atom("WM_DELETE_WINDOW", wm->connection);
 	xcb_icccm_get_text_property_reply_t t_reply;
-	xcb_get_property_cookie_t			cn =
-		xcb_icccm_get_wm_name(wm->connection, win);
+	xcb_get_property_cookie_t cn = xcb_icccm_get_wm_name(wm->connection, win);
 
-	const uint8_t wr =
+	const uint8_t			  wr =
 		xcb_icccm_get_wm_name_reply(wm->connection, cn, &t_reply, NULL);
 	if (supports_protocol(win, wm_delete, wm->connection)) {
 		if (wr == 1) {
 #ifdef _DEBUG__
 			_LOG_(DEBUG,
 				  "window id = %d, reply name = %s: supports "
-				  "WM_DELETE_WINDOW\n",
+				  "WM_DELETE_WINDOW",
 				  win,
 				  t_reply.name);
 #endif
@@ -2849,19 +3039,17 @@ close_or_kill(xcb_window_t win)
 		int ret = send_client_message(
 			win, wm->ewmh->WM_PROTOCOLS, wm_delete, wm->connection);
 		if (ret != 0) {
-			_LOG_(ERROR, "failed to send client message\n");
+			_LOG_(ERROR, "failed to send client message");
 			return -1;
 		}
 		return 0;
 	}
 
-	xcb_void_cookie_t	 c = xcb_kill_client_checked(wm->connection, win);
+	xcb_void_cookie_t	 c	 = xcb_kill_client_checked(wm->connection, win);
 	xcb_generic_error_t *err = xcb_request_check(wm->connection, c);
-	if (err != NULL) {
-		_LOG_(ERROR,
-			  "error closing window: %d, error: %d\n",
-			  win,
-			  err->error_code);
+	if (err) {
+		_LOG_(
+			ERROR, "error closing window: %d, error: %d", win, err->error_code);
 		_FREE_(err);
 		return -1;
 	}
@@ -2879,8 +3067,8 @@ ungrab_keys(xcb_conn_t *conn, xcb_window_t win)
 	xcb_void_cookie_t	cookie =
 		xcb_ungrab_key_checked(conn, XCB_GRAB_ANY, win, modifier);
 	xcb_generic_error_t *err = xcb_request_check(conn, cookie);
-	if (err != NULL) {
-		_LOG_(ERROR, "error ungrabbing keys: %d\n", err->error_code);
+	if (err) {
+		_LOG_(ERROR, "error ungrabbing keys: %d", err->error_code);
 		_FREE_(err);
 	}
 }
@@ -2912,28 +3100,28 @@ find_window_in_desktops(desktop_t  **curr_desktop,
 						bool		*found)
 {
 	monitor_t *curr = head_monitor;
-	while (curr != NULL) {
-		for (int i = 0; i < cur_monitor->n_of_desktops; i++) {
-			desktop_t *d = cur_monitor->desktops[i];
+	while (curr) {
+		for (int i = 0; i < curr_monitor->n_of_desktops; i++) {
+			desktop_t *d = curr_monitor->desktops[i];
 			node_t	  *n = find_node_by_window_id(d->tree, win);
-			if (n != NULL) {
+			if (n) {
 				*curr_desktop = d;
 				*curr_node	  = n;
 				*found		  = true;
-				_LOG_(DEBUG, "Window %d found in desktop %d", win, i);
+				_LOG_(DEBUG, "window %d found in desktop %d", win, i);
 				return;
 			}
 		}
 		curr = curr->next;
 	}
-	_LOG_(ERROR, "Window %d not found in any desktop", win);
+	_LOG_(ERROR, "window %d not found in any desktop", win);
 }
 
 static bool
 client_exist_in_desktops(xcb_window_t win)
 {
 	monitor_t *curr = head_monitor;
-	while (curr != NULL) {
+	while (curr) {
 		for (int i = 0; i < curr->n_of_desktops; ++i) {
 			if (!is_tree_empty(curr->desktops[i]->tree)) {
 				if (client_exist(curr->desktops[i]->tree, win))
@@ -2958,17 +3146,14 @@ kill_window(xcb_window_t win)
 	}
 
 	xcb_icccm_get_text_property_reply_t t_reply;
-	xcb_get_property_cookie_t			cn =
-		xcb_icccm_get_wm_name(wm->connection, win);
-	const uint8_t wr =
+	xcb_get_property_cookie_t cn = xcb_icccm_get_wm_name(wm->connection, win);
+	const uint8_t			  wr =
 		xcb_icccm_get_wm_name_reply(wm->connection, cn, &t_reply, NULL);
 
 	if (wr == 1) {
 #ifdef _DEBUG__
-		_LOG_(DEBUG,
-			  "delete window id = %d, reply name = %s\n",
-			  win,
-			  t_reply.name);
+		_LOG_(
+			DEBUG, "delete window id = %d, reply name = %s", win, t_reply.name);
 #endif
 		xcb_icccm_get_text_property_reply_wipe(&t_reply);
 	}
@@ -2979,26 +3164,26 @@ kill_window(xcb_window_t win)
 		return curi;
 	}
 
-	desktop_t *d			   = cur_monitor->desktops[curi];
+	desktop_t *d			   = curr_monitor->desktops[curi];
 	node_t	  *n			   = find_node_by_window_id(d->tree, win);
-	client_t  *c			   = (n != NULL) ? n->client : NULL;
+	client_t  *c			   = (n) ? n->client : NULL;
 	bool	   another_desktop = false;
 	if (c == NULL) {
 		// window isn't in current desktop
 		find_window_in_desktops(&d, &n, win, &another_desktop);
-		c = (n != NULL) ? n->client : NULL;
+		c = (n) ? n->client : NULL;
 		if (c == NULL) {
 			_LOG_(ERROR, "cannot find client with window %d", win);
 			return -1;
 		}
 	}
 
-	xcb_void_cookie_t cookie = xcb_unmap_window(wm->connection, c->window);
-	xcb_generic_error_t *err = xcb_request_check(wm->connection, cookie);
+	xcb_void_cookie_t	 cookie = xcb_unmap_window(wm->connection, c->window);
+	xcb_generic_error_t *err	= xcb_request_check(wm->connection, cookie);
 
-	if (err != NULL) {
+	if (err) {
 		_LOG_(ERROR,
-			  "Error in unmapping window %d: error code %d",
+			  "error in unmapping window %d: error code %d",
 			  c->window,
 			  err->error_code);
 		_FREE_(err);
@@ -3041,9 +3226,9 @@ set_visibility(xcb_window_t win, bool is_visible)
 	c						 = xcb_change_window_attributes_checked(
 		   wm->connection, wm->root_window, XCB_CW_EVENT_MASK, _off);
 	err = xcb_request_check(wm->connection, c);
-	if (err != NULL) {
+	if (err) {
 		_LOG_(ERROR,
-			  "Cannot change root window %d attrs: error code %d",
+			  "cannot change root window %d attrs: error code %d",
 			  wm->root_window,
 			  err->error_code);
 		_FREE_(err);
@@ -3052,18 +3237,17 @@ set_visibility(xcb_window_t win, bool is_visible)
 
 	ret = is_visible ? show_window(win) : hide_window(win);
 	if (ret == -1) {
-		_LOG_(ERROR,
-			  "cannot set visibilty to %s",
-			  is_visible ? "true" : "false");
+		_LOG_(
+			ERROR, "cannot set visibilty to %s", is_visible ? "true" : "false");
 	}
 
 	// subscribe for events again
 	c = xcb_change_window_attributes_checked(
 		wm->connection, wm->root_window, XCB_CW_EVENT_MASK, _on);
 	err = xcb_request_check(wm->connection, c);
-	if (err != NULL) {
+	if (err) {
 		_LOG_(ERROR,
-			  "Cannot change root window %d attrs: error code %d",
+			  "cannot change root window %d attrs: error code %d",
 			  wm->root_window,
 			  err->error_code);
 		_FREE_(err);
@@ -3083,19 +3267,13 @@ show_window(xcb_window_t win)
 	 **/
 	const long			 data[] = {XCB_ICCCM_WM_STATE_NORMAL, XCB_NONE};
 	const xcb_atom_t	 wm_s	= get_atom("WM_STATE", wm->connection);
-	c	= xcb_change_property_checked(wm->connection,
-									  XCB_PROP_MODE_REPLACE,
-									  win,
-									  wm_s,
-									  wm_s,
-									  32,
-									  2,
-									  data);
+	c							= xcb_change_property_checked(
+		  wm->connection, XCB_PROP_MODE_REPLACE, win, wm_s, wm_s, 32, 2, data);
 	err = xcb_request_check(wm->connection, c);
 
-	if (err != NULL) {
+	if (err) {
 		_LOG_(ERROR,
-			  "Cannot change window property %d: error code %d",
+			  "cannot change window property %d: error code %d",
 			  win,
 			  err->error_code);
 		_FREE_(err);
@@ -3105,9 +3283,9 @@ show_window(xcb_window_t win)
 	c	= xcb_map_window_checked(wm->connection, win);
 	err = xcb_request_check(wm->connection, c);
 
-	if (err != NULL) {
+	if (err) {
 		_LOG_(ERROR,
-			  "Cannot hide window %d: error code %d",
+			  "cannot hide window %d: error code %d",
 			  win,
 			  err->error_code);
 		_FREE_(err);
@@ -3130,19 +3308,13 @@ hide_window(xcb_window_t win)
 	 **/
 	const long			 data[] = {XCB_ICCCM_WM_STATE_ICONIC, XCB_NONE};
 	const xcb_atom_t	 wm_s	= get_atom("WM_STATE", wm->connection);
-	c	= xcb_change_property_checked(wm->connection,
-									  XCB_PROP_MODE_REPLACE,
-									  win,
-									  wm_s,
-									  wm_s,
-									  32,
-									  2,
-									  data);
+	c							= xcb_change_property_checked(
+		  wm->connection, XCB_PROP_MODE_REPLACE, win, wm_s, wm_s, 32, 2, data);
 	err = xcb_request_check(wm->connection, c);
 
-	if (err != NULL) {
+	if (err) {
 		_LOG_(ERROR,
-			  "Cannot change window property %d: error code %d",
+			  "cannot change window property %d: error code %d",
 			  win,
 			  err->error_code);
 		_FREE_(err);
@@ -3151,9 +3323,9 @@ hide_window(xcb_window_t win)
 
 	c	= xcb_unmap_window_checked(wm->connection, win);
 	err = xcb_request_check(wm->connection, c);
-	if (err != NULL) {
+	if (err) {
 		_LOG_(ERROR,
-			  "Cannot hide window %d: error code %d",
+			  "cannot hide window %d: error code %d",
 			  win,
 			  err->error_code);
 		_FREE_(err);
@@ -3197,14 +3369,14 @@ exec_process(arg_t *arg)
 static void
 update_focused_desktop(int id)
 {
-	if (cur_monitor == NULL) {
+	if (curr_monitor == NULL) {
 		return;
 	}
-	for (int i = 0; i < cur_monitor->n_of_desktops; ++i) {
-		if (cur_monitor->desktops[i]->id != id) {
-			cur_monitor->desktops[i]->is_focused = false;
+	for (int i = 0; i < curr_monitor->n_of_desktops; ++i) {
+		if (curr_monitor->desktops[i]->id != id) {
+			curr_monitor->desktops[i]->is_focused = false;
 		} else {
-			cur_monitor->desktops[i]->is_focused = true;
+			curr_monitor->desktops[i]->is_focused = true;
 		}
 	}
 }
@@ -3236,7 +3408,7 @@ switch_desktop_wrapper(arg_t *arg)
 	if (switch_desktop(arg->idx) != 0) {
 		return -1;
 	}
-	node_t *tree = cur_monitor->desktops[arg->idx]->tree;
+	node_t *tree = curr_monitor->desktops[arg->idx]->tree;
 	return render_tree(tree);
 }
 
@@ -3255,11 +3427,11 @@ switch_desktop(const int nd)
 
 	update_focused_desktop(nd);
 
-	if (show_windows(cur_monitor->desktops[nd]->tree) != 0) {
+	if (show_windows(curr_monitor->desktops[nd]->tree) != 0) {
 		return -1;
 	}
 
-	if (hide_windows(cur_monitor->desktops[current]->tree) != 0) {
+	if (hide_windows(curr_monitor->desktops[current]->tree) != 0) {
 		return -1;
 	}
 
@@ -3269,9 +3441,9 @@ switch_desktop(const int nd)
 
 #ifdef _DEBUG__
 	_LOG_(INFO, "new desktop %d nodes--------------", nd + 1);
-	log_tree_nodes(cur_monitor->desktops[nd]->tree);
+	log_tree_nodes(curr_monitor->desktops[nd]->tree);
 	_LOG_(INFO, "old desktop %d nodes--------------", current + 1);
-	log_tree_nodes(cur_monitor->desktops[current]->tree);
+	log_tree_nodes(curr_monitor->desktops[current]->tree);
 #endif
 
 	if (ewmh_update_current_desktop(wm->ewmh, wm->screen_nbr, nd) != 0) {
@@ -3283,31 +3455,14 @@ switch_desktop(const int nd)
 	return 0;
 }
 
-static void
-log_monitors(void)
-{
-	monitor_t *current_monitor = head_monitor;
-	while (current_monitor != NULL) {
-		_LOG_(DEBUG,
-			  "tree for monitor %s:%d id %d",
-			  current_monitor->name,
-			  current_monitor->randr_id,
-			  current_monitor->root);
-		for (int j = 0; j < current_monitor->n_of_desktops; j++) {
-			log_tree_nodes(current_monitor->desktops[j]->tree);
-		}
-		current_monitor = current_monitor->next;
-	}
-}
-
 void
 fill_root_rectangle(rectangle_t *r)
 {
-	const uint16_t w = cur_monitor->rectangle.width;
-	const uint16_t h = cur_monitor->rectangle.height;
-	const uint16_t x = cur_monitor->rectangle.x;
-	const uint16_t y = cur_monitor->rectangle.y;
-	if (wm->bar != NULL && cur_monitor == prim_monitor) {
+	const uint16_t w = curr_monitor->rectangle.width;
+	const uint16_t h = curr_monitor->rectangle.height;
+	const uint16_t x = curr_monitor->rectangle.x;
+	const uint16_t y = curr_monitor->rectangle.y;
+	if (wm->bar && curr_monitor == prim_monitor) {
 		(*r).x		= x + conf.window_gap;
 		(*r).y		= y + wm->bar->rectangle.height + conf.window_gap;
 		(*r).width	= w - 2 * conf.window_gap - 2 * conf.border_width;
@@ -3324,10 +3479,10 @@ fill_root_rectangle(rectangle_t *r)
 static void
 fill_floating_rectangle(xcb_get_geometry_reply_t *geometry, rectangle_t *r)
 {
-	int x = cur_monitor->rectangle.x + (cur_monitor->rectangle.width / 2) -
+	int x = curr_monitor->rectangle.x + (curr_monitor->rectangle.width / 2) -
 			(geometry->width / 2);
-	int y = cur_monitor->rectangle.y +
-			(cur_monitor->rectangle.height / 2) - (geometry->height / 2);
+	int y = curr_monitor->rectangle.y + (curr_monitor->rectangle.height / 2) -
+			(geometry->height / 2);
 	(*r).x		= x;
 	(*r).y		= y;
 	(*r).width	= geometry->width;
@@ -3343,12 +3498,11 @@ cycle_desktop_wrapper(arg_t *arg)
 		return -1;
 	}
 
-	int n_desktops = cur_monitor->n_of_desktops;
-	int next =
-		(current + (arg->d == RIGHT ? 1 : -1) + n_desktops) % n_desktops;
+	int n_desktops = curr_monitor->n_of_desktops;
+	int next = (current + (arg->d == RIGHT ? 1 : -1) + n_desktops) % n_desktops;
 
 	switch_desktop(next);
-	return render_tree(cur_monitor->desktops[next]->tree);
+	return render_tree(curr_monitor->desktops[next]->tree);
 }
 
 static int
@@ -3356,12 +3510,10 @@ set_active_window_name(xcb_window_t win)
 {
 	xcb_void_cookie_t aw_cookie =
 		xcb_ewmh_set_active_window_checked(wm->ewmh, wm->screen_nbr, win);
-	xcb_generic_error_t *err =
-		xcb_request_check(wm->connection, aw_cookie);
+	xcb_generic_error_t *err = xcb_request_check(wm->connection, aw_cookie);
 
 	if (err) {
-		_LOG_(
-			ERROR, "cannot setting active window: %d\n", err->error_code);
+		_LOG_(ERROR, "cannot setting active window: %d", err->error_code);
 		_FREE_(err);
 		return -1;
 	}
@@ -3377,7 +3529,7 @@ set_window_state(xcb_window_t win, xcb_icccm_wm_state_t state)
 	xcb_void_cookie_t c		 = xcb_change_property_checked(
 		 wm->connection, XCB_PROP_MODE_REPLACE, win, t, t, 32, 2, data);
 	xcb_generic_error_t *err = xcb_request_check(wm->connection, c);
-	if (err != NULL) {
+	if (err) {
 		_LOG_(ERROR,
 			  "in changing property window %d: error code %d",
 			  win,
@@ -3418,15 +3570,14 @@ apply_floating_hints(xcb_window_t win)
 	if (1 == r) {
 		/* if min-h == max-h && min-w == max-w, */
 		/* then window should be floated */
-		uint32_t size_mask = (XCB_ICCCM_SIZE_HINT_P_MIN_SIZE |
-							  XCB_ICCCM_SIZE_HINT_P_MAX_SIZE);
-		int32_t	 miw	   = size_hints.min_width;
-		int32_t	 mxw	   = size_hints.max_width;
-		int32_t	 mih	   = size_hints.min_height;
-		int32_t	 mxh	   = size_hints.max_height;
+		uint32_t size_mask =
+			(XCB_ICCCM_SIZE_HINT_P_MIN_SIZE | XCB_ICCCM_SIZE_HINT_P_MAX_SIZE);
+		int32_t miw = size_hints.min_width;
+		int32_t mxw = size_hints.max_width;
+		int32_t mih = size_hints.min_height;
+		int32_t mxh = size_hints.max_height;
 
-		if ((size_hints.flags & size_mask) && (miw == mxw) &&
-			(mih == mxh)) {
+		if ((size_hints.flags & size_mask) && (miw == mxw) && (mih == mxh)) {
 			// window should be floated
 			return 0;
 		}
@@ -3438,11 +3589,11 @@ static int
 find_desktop_by_window(xcb_window_t win)
 {
 	monitor_t *curr = head_monitor;
-	while (curr != NULL) {
-		for (int i = 0; i < cur_monitor->n_of_desktops; i++) {
-			desktop_t *d = cur_monitor->desktops[i];
+	while (curr) {
+		for (int i = 0; i < curr_monitor->n_of_desktops; i++) {
+			desktop_t *d = curr_monitor->desktops[i];
 			node_t	  *n = find_node_by_window_id(d->tree, win);
-			if (n != NULL) {
+			if (n) {
 				return d->id;
 			}
 		}
@@ -3455,9 +3606,8 @@ static int
 window_type(xcb_window_t win)
 {
 	xcb_ewmh_get_atoms_reply_t w_type;
-	xcb_get_property_cookie_t  c =
-		xcb_ewmh_get_wm_window_type(wm->ewmh, win);
-	const uint8_t r =
+	xcb_get_property_cookie_t  c = xcb_ewmh_get_wm_window_type(wm->ewmh, win);
+	const uint8_t			   r =
 		xcb_ewmh_get_wm_window_type_reply(wm->ewmh, c, &w_type, NULL);
 
 	if (r == 1) {
@@ -3548,9 +3698,8 @@ static bool
 should_ignore_hints(xcb_window_t win, const char *name)
 {
 	xcb_icccm_get_wm_class_reply_t t_reply;
-	xcb_get_property_cookie_t	   cn =
-		xcb_icccm_get_wm_class(wm->connection, win);
-	const uint8_t wr =
+	xcb_get_property_cookie_t cn = xcb_icccm_get_wm_class(wm->connection, win);
+	const uint8_t			  wr =
 		xcb_icccm_get_wm_class_reply(wm->connection, cn, &t_reply, NULL);
 	if (wr == 1) {
 		if (strcasecmp(t_reply.class_name, name) == 0) {
@@ -3565,9 +3714,8 @@ should_ignore_hints(xcb_window_t win, const char *name)
 static bool
 window_exists(xcb_conn_t *conn, xcb_window_t win)
 {
-	xcb_query_tree_cookie_t c = xcb_query_tree(conn, win);
-	xcb_query_tree_reply_t *tree_reply =
-		xcb_query_tree_reply(conn, c, NULL);
+	xcb_query_tree_cookie_t c		   = xcb_query_tree(conn, win);
+	xcb_query_tree_reply_t *tree_reply = xcb_query_tree_reply(conn, c, NULL);
 
 	if (tree_reply == NULL) {
 		return false;
@@ -3601,10 +3749,7 @@ handle_first_window(client_t *client, desktop_t *d)
 {
 #ifdef _DEBUG__
 	char *name = win_name(client->window);
-	_LOG_(DEBUG,
-		  "handling first ever window %s id %d",
-		  name,
-		  client->window);
+	_LOG_(DEBUG, "handling first ever window %s id %d", name, client->window);
 	_FREE_(name);
 #endif
 	rectangle_t r = {0};
@@ -3634,16 +3779,15 @@ handle_subsequent_window(client_t *client, desktop_t *d)
 	_FREE_(name);
 #endif
 
-	xcb_window_t wi =
-		get_window_under_cursor(wm->connection, wm->root_window);
-	node_t *n = NULL;
-	/* if (wi == wm->root_window || wi == 0) { */
-	/* 	return 0; */
-	/* } */
-	if (wm->bar != NULL && wi == wm->bar->window) {
+	xcb_window_t wi = get_window_under_cursor(wm->connection, wm->root_window);
+	node_t		*n	= NULL;
+	/*if (wi == wm->root_window || wi == 0) {
+		return 0;
+	}*/
+	if (wm->bar && wi == wm->bar->window) {
 		n = find_any_leaf(d->tree);
 	} else {
-		/* n = find_node_by_window_id(d->tree, wi); */
+		/* n = find_node_by_window_id(d->tree, wi);*/
 		n = get_focused_node(d->tree);
 		if (n == NULL || n->client == NULL) {
 			_LOG_(ERROR, "cannot find focused node");
@@ -3695,8 +3839,7 @@ handle_floating_window(client_t *client, desktop_t *d)
 {
 #ifdef _DEBUG__
 	char *name = win_name(client->window);
-	_LOG_(
-		DEBUG, "handling floating window %s id %d", name, client->window);
+	_LOG_(DEBUG, "handling floating window %s id %d", name, client->window);
 	_FREE_(name);
 #endif
 
@@ -3757,9 +3900,9 @@ handle_floating_window(client_t *client, desktop_t *d)
 static int
 insert_into_desktop(int idx, xcb_window_t win, bool is_tiled)
 {
-	desktop_t *d = cur_monitor->desktops[--idx];
-	assert(d != NULL);
-	if (find_node_by_window_id(d->tree, win) != NULL) {
+	desktop_t *d = curr_monitor->desktops[--idx];
+	assert(d);
+	if (find_node_by_window_id(d->tree, win)) {
 		return 0;
 	}
 	client_t *client = create_client(win, XCB_ATOM_WINDOW, wm->connection);
@@ -3774,16 +3917,16 @@ insert_into_desktop(int idx, xcb_window_t win, bool is_tiled)
 	}
 	if (is_tree_empty(d->tree)) {
 		rectangle_t	   r = {0};
-		const uint16_t w = cur_monitor->rectangle.width;
-		const uint16_t h = cur_monitor->rectangle.height;
-		const uint16_t x = cur_monitor->rectangle.x;
-		const uint16_t y = cur_monitor->rectangle.y;
-		if (wm->bar != NULL && cur_monitor == prim_monitor) {
+		const uint16_t w = curr_monitor->rectangle.width;
+		const uint16_t h = curr_monitor->rectangle.height;
+		const uint16_t x = curr_monitor->rectangle.x;
+		const uint16_t y = curr_monitor->rectangle.y;
+		if (wm->bar && curr_monitor == prim_monitor) {
 			r.x		 = x + conf.window_gap;
 			r.y		 = y + wm->bar->rectangle.height + conf.window_gap;
 			r.width	 = w - 2 * conf.window_gap - 2 * conf.border_width;
-			r.height = h - wm->bar->rectangle.height -
-					   2 * conf.window_gap - 2 * conf.border_width;
+			r.height = h - wm->bar->rectangle.height - 2 * conf.window_gap -
+					   2 * conf.border_width;
 		} else {
 			r.x		 = x + conf.window_gap;
 			r.y		 = y + conf.window_gap;
@@ -3810,21 +3953,17 @@ insert_into_desktop(int idx, xcb_window_t win, bool is_tiled)
 			_FREE_(name);
 			return 0;
 		}
-
 		if (n->client->state == FLOATING) {
 			return 0;
 		}
-
 		if (n->client->state == FULLSCREEN) {
 			set_fullscreen(n, false);
 		}
-
 		node_t *new_node = create_node(client);
 		if (new_node == NULL) {
 			_LOG_(ERROR, "new node is null");
 			return -1;
 		}
-
 		if (new_node->client->state == FLOATING) {
 			xcb_get_geometry_reply_t *g =
 				get_geometry(client->window, wm->connection);
@@ -3832,9 +3971,8 @@ insert_into_desktop(int idx, xcb_window_t win, bool is_tiled)
 				_LOG_(ERROR, "cannot get %d geometry", client->window);
 				return -1;
 			}
-
-			int x = (cur_monitor->rectangle.width / 2) - (g->width / 2);
-			int y = (cur_monitor->rectangle.height / 2) - (g->height / 2);
+			int x = (curr_monitor->rectangle.width / 2) - (g->width / 2);
+			int y = (curr_monitor->rectangle.height / 2) - (g->height / 2);
 			rectangle_t rc = {
 				.x = x, .y = y, .width = g->width, .height = g->height};
 			new_node->rectangle = new_node->floating_rectangle = rc;
@@ -3856,13 +3994,12 @@ handle_map_request(const xcb_map_request_event_t *ev)
 	xcb_window_t win = ev->window;
 
 	monitor_t	*mm	 = get_focused_monitor();
-	if (mm != NULL && mm != cur_monitor) {
-		cur_monitor = mm;
+	if (mm && mm != curr_monitor) {
+		curr_monitor = mm;
 	}
 
 	if (!should_manage(win, wm->connection)) {
-		_LOG_(
-			INFO, "win %d, shouldn't be managed.. ignoring request", win);
+		_LOG_(INFO, "win %d, shouldn't be managed.. ignoring request", win);
 		return 0;
 	}
 
@@ -3873,15 +4010,15 @@ handle_map_request(const xcb_map_request_event_t *ev)
 	}
 
 	// check if the window already exists in the tree to avoid duplication
-	if (find_node_by_window_id(cur_monitor->desktops[idx]->tree, win) !=
+	if (find_node_by_window_id(curr_monitor->desktops[idx]->tree, win) !=
 		NULL) {
 		return 0;
 	}
 
-	desktop_t *d	= cur_monitor->desktops[idx];
+	desktop_t *d	= curr_monitor->desktops[idx];
 	rule_t	  *rule = get_window_rule(win);
 
-	if (rule != NULL) {
+	if (rule) {
 		if (rule->desktop_id != -1) {
 			return insert_into_desktop(
 				rule->desktop_id, win, rule->state == TILED);
@@ -3894,16 +4031,13 @@ handle_map_request(const xcb_map_request_event_t *ev)
 	}
 
 	int wint = window_type(win);
-
 	if ((apply_floating_hints(win) != -1 && wint != 2)) {
 		return handle_floating_window_request(win, d);
 	}
-
 	if (wint == 7) {
 		map_floating(win);
 		return 0;
 	}
-
 	switch (wint) {
 	case -1:
 	case 0:
@@ -3963,7 +4097,7 @@ handle_floating_window_request(xcb_window_t win, desktop_t *d)
 static int
 handle_bar_request(xcb_window_t win, desktop_t *d)
 {
-	if (wm->bar != NULL) {
+	if (wm->bar) {
 		return 0;
 	}
 
@@ -3994,8 +4128,8 @@ handle_enter_notify(const xcb_enter_notify_event_t *ev)
 {
 	xcb_window_t win = ev->event;
 	monitor_t	*mm	 = get_focused_monitor();
-	if (mm != NULL && mm != cur_monitor) {
-		cur_monitor = mm;
+	if (mm && mm != curr_monitor) {
+		curr_monitor = mm;
 	}
 #ifdef _DEBUG__
 	char *name = win_name(win);
@@ -4008,7 +4142,7 @@ handle_enter_notify(const xcb_enter_notify_event_t *ev)
 		return 0;
 	}
 
-	if (wm->bar != NULL && win == wm->bar->window) {
+	if (wm->bar && win == wm->bar->window) {
 		return 0;
 	}
 
@@ -4020,10 +4154,12 @@ handle_enter_notify(const xcb_enter_notify_event_t *ev)
 	if (curd == -1)
 		return curd;
 
-	node_t	 *root	 = cur_monitor->desktops[curd]->tree;
-
+	node_t *root = curr_monitor->desktops[curd]->tree;
+	if (!root) {
+		return -1;
+	}
 	node_t	 *n		 = find_node_by_window_id(root, win);
-	client_t *client = (n != NULL && n->client != NULL) ? n->client : NULL;
+	client_t *client = (n && n->client) ? n->client : NULL;
 
 	if (client == NULL || n == NULL) {
 		return 0;
@@ -4059,9 +4195,7 @@ handle_enter_notify(const xcb_enter_notify_event_t *ev)
 
 	if (IS_FLOATING(n->client)) {
 		if (win_focus(n->client->window, true) != 0) {
-			_LOG_(ERROR,
-				  "cannot focus window %d (enter)",
-				  n->client->window);
+			_LOG_(ERROR, "cannot focus window %d (enter)", n->client->window);
 			return -1;
 		}
 		n->is_focused = true;
@@ -4071,11 +4205,10 @@ handle_enter_notify(const xcb_enter_notify_event_t *ev)
 			return -1;
 		}
 	} else {
-		if (cur_monitor->desktops[curd]->layout == STACK) {
+		if (curr_monitor->desktops[curd]->layout == STACK) {
 			if (win_focus(n->client->window, true) != 0) {
-				_LOG_(ERROR,
-					  "cannot focus window %d (enter)",
-					  n->client->window);
+				_LOG_(
+					ERROR, "cannot focus window %d (enter)", n->client->window);
 				return -1;
 			}
 			n->is_focused = true;
@@ -4113,7 +4246,7 @@ handle_leave_notify(const xcb_leave_notify_event_t *ev)
 	_FREE_(name);
 #endif
 
-	if (wm->bar != NULL && win == wm->bar->window) {
+	if (wm->bar && win == wm->bar->window) {
 		return 0;
 	}
 
@@ -4129,14 +4262,14 @@ handle_leave_notify(const xcb_leave_notify_event_t *ev)
 	const int curd = get_focused_desktop_idx();
 	if (curd == -1)
 		return -1;
-	if (cur_monitor->desktops[curd]->layout == STACK) {
+	if (curr_monitor->desktops[curd]->layout == STACK) {
 		return 0;
 	}
 
-	node_t		*root		   = cur_monitor->desktops[curd]->tree;
+	node_t		*root		   = curr_monitor->desktops[curd]->tree;
 	xcb_window_t active_window = XCB_NONE;
 	node_t		*n			   = find_node_by_window_id(root, win);
-	client_t *client = (n != NULL && n->client != NULL) ? n->client : NULL;
+	client_t	*client		   = (n && n->client) ? n->client : NULL;
 	if (client == NULL) {
 		return 0;
 	}
@@ -4151,7 +4284,7 @@ handle_leave_notify(const xcb_leave_notify_event_t *ev)
 
 	if (set_focus(n, false) != 0) {
 		_LOG_(ERROR,
-			  "failed to change border attr for window %d\n",
+			  "failed to change border attr for window %d",
 			  client->window);
 		return -1;
 	}
@@ -4163,19 +4296,18 @@ static void
 handle_key_press(const xcb_key_press_event_t *key_press)
 {
 	uint16_t	 cleaned_state = (key_press->state & ~(XCB_MOD_MASK_LOCK));
-	xcb_keysym_t k = get_keysym(key_press->detail, wm->connection);
+	xcb_keysym_t k			   = get_keysym(key_press->detail, wm->connection);
 
-	if (key_head != NULL) {
-		_LOG_(INFO, "----grabbing conf keys------\n");
+	if (key_head) {
+		_LOG_(INFO, "----grabbing conf keys------");
 		conf_key_t *current = key_head;
-		while (current != NULL) {
+		while (current) {
 			if (cleaned_state == (current->mod & ~(XCB_MOD_MASK_LOCK))) {
 				if (current->keysym == k) {
 					arg_t *a   = current->arg;
 					int	   ret = current->function_ptr(a);
 					if (ret != 0) {
-						_LOG_(ERROR,
-							  "error while executing function_ptr(..)");
+						_LOG_(ERROR, "error while executing function_ptr(..)");
 					}
 					break;
 				}
@@ -4185,7 +4317,7 @@ handle_key_press(const xcb_key_press_event_t *key_press)
 		return;
 	}
 
-	// _LOG_(INFO, "----using default keys------\n");
+	// _LOG_(INFO, "----using default keys------");
 	size_t n = sizeof(keys_) / sizeof(keys_[0]);
 	for (size_t i = n; i--;) {
 		if (cleaned_state == (keys_[i].mod & ~(XCB_MOD_MASK_LOCK))) {
@@ -4238,7 +4370,7 @@ handle_state(node_t		 *n,
 			  "_NET_WM_STATE_BELOW received for win %d:%s",
 			  n->client->window,
 			  name);
-		if (cur_monitor->desktops[get_focused_desktop_idx()]->layout !=
+		if (curr_monitor->desktops[get_focused_desktop_idx()]->layout !=
 			STACK) {
 			lower_window(n->client->window);
 		}
@@ -4247,7 +4379,7 @@ handle_state(node_t		 *n,
 			  "_NET_WM_STATE_ABOVE received for win %d:%s",
 			  n->client->window,
 			  name);
-		if (cur_monitor->desktops[get_focused_desktop_idx()]->layout !=
+		if (curr_monitor->desktops[get_focused_desktop_idx()]->layout !=
 			STACK) {
 			raise_window(n->client->window);
 		}
@@ -4292,15 +4424,14 @@ handle_client_message(const xcb_client_message_event_t *client_message)
 	if (d == -1)
 		return d;
 
-	node_t *root = cur_monitor->desktops[d]->tree;
+	node_t *root = curr_monitor->desktops[d]->tree;
 
 	node_t *n	 = find_node_by_window_id(root, client_message->window);
 	// node_t reciever fonctions will perform the null check for n
 #ifdef _DEBUG__
-	_LOG_(DEBUG, "received data32 for win %d:\n", client_message->window);
+	_LOG_(DEBUG, "received data32 for win %d:", client_message->window);
 	for (ulong i = 0; i < LEN(client_message->data.data32); i++) {
-		_LOG_(
-			DEBUG, "data32[%d]: %u\n", i, client_message->data.data32[i]);
+		_LOG_(DEBUG, "data32[%d]: %u", i, client_message->data.data32[i]);
 	}
 #endif
 	char *s = win_name(client_message->window);
@@ -4382,11 +4513,11 @@ handle_unmap_notify(xcb_unmap_notify_event_t *ev)
 	_FREE_(s);
 #endif
 
-	node_t *root = cur_monitor->desktops[idx]->tree;
+	node_t *root = curr_monitor->desktops[idx]->tree;
 	if (root == NULL)
 		return 0;
 
-	if (wm->bar != NULL && wm->bar->window == win) {
+	if (wm->bar && wm->bar->window == win) {
 		hide_bar(win);
 		render_tree(root);
 		return 0;
@@ -4428,7 +4559,7 @@ handle_configure_request(const xcb_configure_request_event_t *e)
 	}
 #ifdef _DEBUG__
 	_LOG_(DEBUG,
-		  "window %d  name %s wants to be at %dx%d with %dx%d\n",
+		  "window %d  name %s wants to be at %dx%d with %dx%d",
 		  win,
 		  name,
 		  e->x,
@@ -4442,7 +4573,7 @@ handle_configure_request(const xcb_configure_request_event_t *e)
 		return;
 	}
 
-	node_t *n		   = cur_monitor->desktops[d]->tree;
+	node_t *n		   = curr_monitor->desktops[d]->tree;
 	bool	is_managed = client_exist(n, win);
 	if (!is_managed) {
 		uint16_t mask = 0;
@@ -4510,11 +4641,11 @@ handle_destroy_notify(const xcb_destroy_notify_event_t *ev)
 	_FREE_(s);
 #endif
 
-	node_t *root = cur_monitor->desktops[idx]->tree;
+	node_t *root = curr_monitor->desktops[idx]->tree;
 	if (root == NULL)
 		return 0;
 
-	if (wm->bar != NULL && wm->bar->window == win) {
+	if (wm->bar && wm->bar->window == win) {
 		hide_bar(win);
 		render_tree(root);
 		return 0;
@@ -4543,7 +4674,7 @@ update_grabbed_window(node_t *root, node_t *n)
 	if (root == NULL)
 		return;
 
-	bool flag = !IS_INTERNAL(root) && root->client != NULL;
+	bool flag = !IS_INTERNAL(root) && root->client;
 	if (flag && root != n) {
 		set_focus(root, false);
 		window_grab_buttons(root->client->window);
@@ -4581,7 +4712,7 @@ handle_button_press_event(const xcb_button_press_event_t *ev)
 
 	xcb_window_t win = ev->event;
 
-	if (wm->bar != NULL && win == wm->bar->window) {
+	if (wm->bar && win == wm->bar->window) {
 		return;
 	}
 
@@ -4593,9 +4724,9 @@ handle_button_press_event(const xcb_button_press_event_t *ev)
 	if (curd == -1)
 		return;
 
-	node_t	 *root	 = cur_monitor->desktops[curd]->tree;
+	node_t	 *root	 = curr_monitor->desktops[curd]->tree;
 	node_t	 *n		 = find_node_by_window_id(root, win);
-	client_t *client = (n != NULL && n->client != NULL) ? n->client : NULL;
+	client_t *client = (n && n->client) ? n->client : NULL;
 
 	if (client == NULL) {
 		return;
@@ -4616,9 +4747,7 @@ handle_button_press_event(const xcb_button_press_event_t *ev)
 
 	if (IS_FLOATING(n->client)) {
 		if (win_focus(n->client->window, true) != 0) {
-			_LOG_(ERROR,
-				  "cannot focus window %d (enter)",
-				  n->client->window);
+			_LOG_(ERROR, "cannot focus window %d (enter)", n->client->window);
 			return;
 		}
 		n->is_focused = true;
@@ -4628,11 +4757,10 @@ handle_button_press_event(const xcb_button_press_event_t *ev)
 			return;
 		}
 	} else {
-		if (cur_monitor->desktops[curd]->layout == STACK) {
+		if (curr_monitor->desktops[curd]->layout == STACK) {
 			if (win_focus(n->client->window, true) != 0) {
-				_LOG_(ERROR,
-					  "cannot focus window %d (enter)",
-					  n->client->window);
+				_LOG_(
+					ERROR, "cannot focus window %d (enter)", n->client->window);
 				return;
 			}
 			n->is_focused = true;
@@ -4680,29 +4808,26 @@ handle_mapping_notify(const xcb_mapping_notify_event_t *e)
 static void
 log_children(xcb_conn_t *conn, xcb_window_t root_window)
 {
-	xcb_query_tree_cookie_t tree_cookie =
-		xcb_query_tree(conn, root_window);
+	xcb_query_tree_cookie_t tree_cookie = xcb_query_tree(conn, root_window);
 	xcb_query_tree_reply_t *tree_reply =
 		xcb_query_tree_reply(conn, tree_cookie, NULL);
 	if (tree_reply == NULL) {
-		_LOG_(ERROR, "failed to query tree reply\n");
+		_LOG_(ERROR, "failed to query tree reply");
 		return;
 	}
 
-	_LOG_(DEBUG, "children of root window:\n");
-	xcb_window_t *children = xcb_query_tree_children(tree_reply);
-	const int num_children = xcb_query_tree_children_length(tree_reply);
+	_LOG_(DEBUG, "children of root window:");
+	xcb_window_t *children	   = xcb_query_tree_children(tree_reply);
+	const int	  num_children = xcb_query_tree_children_length(tree_reply);
 	for (int i = 0; i < num_children; ++i) {
 		xcb_icccm_get_text_property_reply_t t_reply;
-		xcb_get_property_cookie_t			cn =
-			xcb_icccm_get_wm_name(conn, children[i]);
+		xcb_get_property_cookie_t cn = xcb_icccm_get_wm_name(conn, children[i]);
 		uint8_t wr = xcb_icccm_get_wm_name_reply(conn, cn, &t_reply, NULL);
 		if (wr == 1) {
-			_LOG_(DEBUG, "child %d: %s\n", i + 1, t_reply.name);
+			_LOG_(DEBUG, "child %d: %s", i + 1, t_reply.name);
 			xcb_icccm_get_text_property_reply_wipe(&t_reply);
 		} else {
-			_LOG_(
-				DEBUG, "failed to get window name for child %d\n", i + 1);
+			_LOG_(DEBUG, "failed to get window name for child %d", i + 1);
 		}
 	}
 
@@ -4718,7 +4843,7 @@ parse_args(int argc, char **argv)
 		if (argc >= 2) {
 			c = argv[2];
 		} else {
-			_LOG_(ERROR, "missing argument after -r/--run\n");
+			_LOG_(ERROR, "missing argument after -r/--run");
 		}
 	}
 	exec_process(&((arg_t){.argc = 1, .cmd = (char *[]){c}}));
@@ -4735,7 +4860,7 @@ event_loop(wm_t *w)
 				(xcb_map_request_event_t *)event;
 			if (handle_map_request(map_request) != 0) {
 				_LOG_(ERROR,
-					  "failed to handle MAP_REQUEST for window %d\n",
+					  "failed to handle MAP_REQUEST for window %d",
 					  map_request->window);
 			}
 			break;
@@ -4746,7 +4871,7 @@ event_loop(wm_t *w)
 			if (handle_unmap_notify(unmap_notify) != 0) {
 				_LOG_(ERROR,
 					  "failed to handle XCB_UNMAP_NOTIFY for "
-					  "window %d\n",
+					  "window %d",
 					  unmap_notify->window);
 			}
 			break;
@@ -4757,7 +4882,7 @@ event_loop(wm_t *w)
 			if (handle_destroy_notify(destroy_notify) != 0) {
 				_LOG_(ERROR,
 					  "failed to handle XCB_DESTROY_NOTIFY for "
-					  "window %d\n",
+					  "window %d",
 					  destroy_notify->window);
 			}
 			break;
@@ -4797,7 +4922,7 @@ event_loop(wm_t *w)
 			if (handle_enter_notify(enter_event) != 0) {
 				_LOG_(ERROR,
 					  "failed to handle XCB_ENTER_NOTIFY for "
-					  "window %d\n",
+					  "window %d",
 					  enter_event->event);
 			}
 			break;
@@ -4808,14 +4933,13 @@ event_loop(wm_t *w)
 			// if (handle_leave_notify(leave_event) != 0) {
 			// 	_LOG_(ERROR,
 			// 				"Failed to handle XCB_LEAVE_NOTIFY for "
-			// 				"window %d\n",
+			// 				"window %d",
 			// 				leave_event->event);
 			// }
 			break;
 		}
 		case XCB_MOTION_NOTIFY: {
-			__attribute__((unused))
-			xcb_motion_notify_event_t *motion_notify =
+			__attribute__((unused)) xcb_motion_notify_event_t *motion_notify =
 				(xcb_motion_notify_event_t *)event;
 			break;
 		}
@@ -4826,14 +4950,12 @@ event_loop(wm_t *w)
 			break;
 		}
 		case XCB_BUTTON_RELEASE: {
-			__attribute__((unused))
-			xcb_button_release_event_t *button_release =
+			__attribute__((unused)) xcb_button_release_event_t *button_release =
 				(xcb_button_release_event_t *)event;
 			break;
 		}
 		case XCB_KEY_PRESS: {
-			xcb_key_press_event_t *key_press =
-				(xcb_key_press_event_t *)event;
+			xcb_key_press_event_t *key_press = (xcb_key_press_event_t *)event;
 			handle_key_press(key_press);
 			break;
 		}
@@ -4848,8 +4970,7 @@ event_loop(wm_t *w)
 			break;
 		}
 		case XCB_FOCUS_OUT: {
-			__attribute__((unused))
-			xcb_focus_out_event_t *focus_out_event =
+			__attribute__((unused)) xcb_focus_out_event_t *focus_out_event =
 				(xcb_focus_out_event_t *)event;
 			break;
 		}
@@ -4857,8 +4978,18 @@ event_loop(wm_t *w)
 			xcb_mapping_notify_event_t *mapping_notify =
 				(xcb_mapping_notify_event_t *)event;
 			handle_mapping_notify(mapping_notify);
+			break;
 		}
 		default: {
+			if (using_xrandr) {
+				if ((event->response_type & ~0x80) ==
+					randr_base + XCB_RANDR_SCREEN_CHANGE_NOTIFY) {
+					_LOG_(INFO, "monitor update was requested");
+					handle_monitor_changes();
+					// xrandr --output eDP1 --auto --output HDMI1 --auto
+					// --right-of eDP1
+				}
+			}
 			break;
 		}
 		}
@@ -4876,7 +5007,6 @@ cleanup(int sig)
 	free_monitors(); // frees desktops and trees as well
 	_FREE_(wm);
 	_LOG_(INFO, "ZWM exits with signal number %d", sig);
-
 	// uncommenting the following line *exit(sig)* prevents the os
 	// from generating a core dump file when zwm crashes
 	// exit(sig);
@@ -4898,12 +5028,12 @@ main(int argc, char **argv)
 
 	wm = init_wm();
 	if (wm == 0x00) {
-		_LOG_(ERROR, "failed to initialize window manager\n");
+		_LOG_(ERROR, "failed to initialize window manager");
 		exit(EXIT_FAILURE);
 	}
 
 	if (!setup_wm()) {
-		_LOG_(ERROR, "failed to setup window manager\n");
+		_LOG_(ERROR, "failed to setup window manager");
 		exit(EXIT_FAILURE);
 	}
 

--- a/src/zwm.c
+++ b/src/zwm.c
@@ -1073,7 +1073,7 @@ change_colors(node_t *root)
 	return 0;
 }
 
-/* TODO: rewrite this shit */
+/* TODO: rewrite this */
 static void
 apply_monitor_layout_changes(monitor_t *m)
 {

--- a/src/zwm.c
+++ b/src/zwm.c
@@ -82,7 +82,7 @@
 	(PROPERTY_CHANGE | FOCUS_CHANGE | ENTER_WINDOW | LEAVE_WINDOW)
 
 #define ROOT_EVENT_MASK                                                        \
-	(SUBSTRUCTURE | BUTTON_PRESS | FOCUS_CHANGE | POINTER_MOTION | ENTER_WINDOW)
+	(SUBSTRUCTURE | BUTTON_PRESS | FOCUS_CHANGE | ENTER_WINDOW)
 
 #define NUMBER_OF_DESKTOPS 7
 #define WM_NAME			   "zwm"
@@ -2142,6 +2142,7 @@ setup_monitors(void)
 		m->is_occupied = false;
 		m->is_wired	   = false;
 		m->randr_id	   = 0;
+		m->desktops	   = NULL;
 		add_monitor(&head_monitor, m);
 		prim_monitor = curr_monitor = m;
 		goto out; /* skip to the end of the function */
@@ -4426,12 +4427,11 @@ handle_enter_notify(const xcb_event_t *event)
 	xcb_enter_notify_event_t *ev  = (xcb_enter_notify_event_t *)event;
 	xcb_window_t			  win = ev->event;
 
-	if (multi_monitors) {
-		monitor_t *mm = get_focused_monitor();
-		if (mm && mm != curr_monitor) {
-			curr_monitor = mm;
-		}
+	monitor_t				 *mm  = get_focused_monitor();
+	if (mm && mm != curr_monitor) {
+		curr_monitor = mm;
 	}
+
 #ifdef _DEBUG__
 	char *name = win_name(win);
 	_LOG_(DEBUG, "recieved enter notify for %d, name %s ", win, name);

--- a/src/zwm.h
+++ b/src/zwm.h
@@ -39,7 +39,7 @@ extern wm_t 			  *wm;
 extern xcb_window_t 	  focused_win;
 extern monitor_t 		  *head_monitor;
 extern monitor_t		  *prim_monitor;
-extern monitor_t 		  *cur_monitor;
+extern monitor_t 		  *curr_monitor;
 extern bool 			  using_xrandr;
 extern bool 		      using_xinerama;
 extern uint8_t 			  randr_base;

--- a/src/zwm.h
+++ b/src/zwm.h
@@ -61,6 +61,8 @@ int 		 flip_node_wrapper();
 int          reload_config_wrapper();
 int          get_focused_desktop_idx();
 int 		 switch_desktop_wrapper(arg_t *arg);
+int	         transfer_node_wrapper(arg_t *arg);
+int 	     horizontal_resize_wrapper(arg_t *arg);
 int 		 gap_handler(arg_t *arg);
 int 		 cycle_desktop_wrapper(arg_t *arg);
 int 	     close_or_kill_wrapper();

--- a/src/zwm.h
+++ b/src/zwm.h
@@ -33,7 +33,7 @@
 #include <xcb/xcb_icccm.h>
 #include <xcb/xproto.h>
 
-// clang-format off
+/* clang-format off */
 extern config_t 		  conf;
 extern wm_t 			  *wm;
 extern xcb_window_t 	  focused_win;
@@ -45,32 +45,33 @@ extern bool 		      using_xinerama;
 extern uint8_t 			  randr_base;
 
 xcb_window_t get_window_under_cursor(xcb_conn_t *conn, xcb_window_t win);
-void 		 raise_window(xcb_window_t win);
-void 		 lower_window(xcb_window_t win);
-void         window_grab_buttons(xcb_window_t win);
-void 		 window_above(xcb_window_t, xcb_window_t);
-void 		 window_below(xcb_window_t, xcb_window_t);
-void         grab_pointer(xcb_window_t, bool);
-void         ungrab_pointer(void);
-int          set_visibility(xcb_window_t win, bool is_visible);
-int          exec_process(arg_t *arg);
-int 	     layout_handler(arg_t *arg);
-int    	     cycle_win_wrapper(arg_t *arg);
-int  		 set_fullscreen_wrapper();
-int 		 flip_node_wrapper();
-int          reload_config_wrapper();
-int          get_focused_desktop_idx();
-int 		 switch_desktop_wrapper(arg_t *arg);
-int	         transfer_node_wrapper(arg_t *arg);
-int 	     horizontal_resize_wrapper(arg_t *arg);
-int 		 gap_handler(arg_t *arg);
-int 		 cycle_desktop_wrapper(arg_t *arg);
-int 	     close_or_kill_wrapper();
-int 		 traverse_stack_wrapper(arg_t *arg);
-int 		 shift_floating_window(arg_t *arg);
-int          tile(node_t *node);
-int 		 set_focus(node_t *n, bool flag);
-int 		 swap_node_wrapper();
-int          change_state(arg_t *arg);
-char        *win_name(xcb_window_t);
-#endif // ZWM_ZWM_H
+void raise_window(xcb_window_t win);
+void lower_window(xcb_window_t win);
+void window_grab_buttons(xcb_window_t win);
+void window_above(xcb_window_t, xcb_window_t);
+void window_below(xcb_window_t, xcb_window_t);
+void grab_pointer(xcb_window_t, bool);
+void ungrab_pointer(void);
+char *win_name(xcb_window_t);
+int set_visibility(xcb_window_t win, bool is_visible);
+int exec_process(arg_t *arg);
+int layout_handler(arg_t *arg);
+int cycle_win_wrapper(arg_t *arg);
+int set_fullscreen_wrapper();
+int flip_node_wrapper();
+int reload_config_wrapper();
+int get_focused_desktop_idx();
+int switch_desktop_wrapper(arg_t *arg);
+int transfer_node_wrapper(arg_t *arg);
+int horizontal_resize_wrapper(arg_t *arg);
+int gap_handler(arg_t *arg);
+int cycle_desktop_wrapper(arg_t *arg);
+int close_or_kill_wrapper();
+int traverse_stack_wrapper(arg_t *arg);
+int shift_floating_window(arg_t *arg);
+int tile(node_t *node);
+int set_focus(node_t *n, bool flag);
+int swap_node_wrapper();
+int change_state(arg_t *arg);
+/* clang-format on */
+#endif /* ZWM_ZWM_H */


### PR DESCRIPTION
This PR introduces:
1- fix for #29 
2- fix memory leak when freeing keys
3- fix for `swap_node` logic
4- handling monitor changes on the fly, this includes connecting, disconnecting or changing monitor layout while the wm is running.