### PR TITLE
sync EWMH states for external consumers + add EWMH struts (_NET_WM_STRUT_PARTIAL) to reserve screen space for panels 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The motivation behind zwm stems from a desire to create a window manager that is
 - Customizable settings.
 - Customizable window rules.
 - Can be integrated with any status bar.
+- Can handle multiple bars per monitor/display, in different locations (top, bottom, left, right).
 - Config reload on the fly.
 
 ## The underlying data structure:

--- a/src/logger.c
+++ b/src/logger.c
@@ -41,9 +41,9 @@
 #define LOG_FILE	 "zwm.log"
 #define MAX_PATH_LEN (2 << 7)
 #ifdef _DEBUG__
-#define MAX_LOG_SIZE (2 << 15) // ~64kb
+#define MAX_LOG_SIZE (2 << 15) /* ~64kb */
 #else
-#define MAX_LOG_SIZE (2 << 12) // ~8kb
+#define MAX_LOG_SIZE (2 << 12) /* ~8kb */
 #endif
 
 void

--- a/src/logger.c
+++ b/src/logger.c
@@ -26,8 +26,8 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "type.h"
 #include "helper.h"
+#include "type.h"
 #include <pwd.h>
 #include <stdarg.h>
 #include <stdbool.h>

--- a/src/tree.c
+++ b/src/tree.c
@@ -206,7 +206,7 @@ render_tree_internal(node_t *node, bool do_map)
 
 	queue_t *q = create_queue();
 	if (!q) {
-		_LOG_(ERROR, "queue creation failed");
+_LOG_(ERROR, "queue creation failed");
 		return -1;
 	}
 
@@ -852,7 +852,7 @@ restack(void)
 	int		 top		= -1;
 	node_t **stack		= (node_t **)malloc(sizeof(node_t *) * stack_size);
 	if (stack == NULL) {
-		_LOG_(ERROR, "cannot allocate stack");
+_LOG_(ERROR, "cannot allocate stack");
 		return;
 	}
 	stack_and_lower(
@@ -1213,22 +1213,13 @@ apply_default_layout(node_t *root)
 static void
 calculate_base_rect(rectangle_t *r, monitor_t *m)
 {
-	uint16_t w = m->rectangle.width;
-	uint16_t h = m->rectangle.height;
-	uint16_t x = m->rectangle.x;
-	uint16_t y = m->rectangle.y;
-	if (wm->bar && m == prim_monitor) {
-		r->x	  = (int16_t)(x + conf.window_gap);
-		r->y	  = (int16_t)(y + wm->bar->rectangle.height + conf.window_gap);
-		r->width  = (uint16_t)(w - 2 * conf.window_gap - 2 * conf.border_width);
-		r->height = (uint16_t)(h - wm->bar->rectangle.height -
-							   2 * conf.window_gap - 2 * conf.border_width);
-	} else {
-		r->x	  = (int16_t)(x + conf.window_gap);
-		r->y	  = (int16_t)(y + conf.window_gap);
-		r->width  = (uint16_t)(w - 2 * conf.window_gap - 2 * conf.border_width);
-		r->height = (uint16_t)(h - 2 * conf.window_gap - 2 * conf.border_width);
-	}
+	rectangle_t usable = get_usable_area(m);
+	r->x			   = (int16_t)(usable.x + conf.window_gap);
+	r->y			   = (int16_t)(usable.y + conf.window_gap);
+	r->width =
+		(uint16_t)(usable.width - 2 * conf.window_gap - 2 * conf.border_width);
+	r->height =
+		(uint16_t)(usable.height - 2 * conf.window_gap - 2 * conf.border_width);
 }
 
 /* default_layout - applies the default layout to the tree.
@@ -1319,13 +1310,10 @@ static void
 master_layout(node_t *root, node_t *n)
 {
 	const double   ratio		= 0.70;
-	const uint16_t w			= curr_monitor->rectangle.width;
-	const uint16_t h			= curr_monitor->rectangle.height;
-	const uint16_t x			= curr_monitor->rectangle.x;
-	const uint16_t y			= curr_monitor->rectangle.y;
-	const uint16_t master_width = (uint16_t)(w * ratio);
-	const uint16_t r_width		= (uint16_t)(w * (1 - ratio));
-	const uint16_t bar_height = wm->bar == NULL ? 0 : wm->bar->rectangle.height;
+
+	rectangle_t	   usable		= get_usable_area(curr_monitor);
+	const uint16_t master_width = (uint16_t)(usable.width * ratio);
+	const uint16_t r_width		= (uint16_t)(usable.width * (1 - ratio));
 
 	/* find a node to be master if not provided */
 	if (n == NULL) {
@@ -1339,18 +1327,18 @@ master_layout(node_t *root, node_t *n)
 
 	/* master rectangle */
 	const rectangle_t r1 = {
-		.x		= (int16_t)(x + conf.window_gap),
-		.y		= (int16_t)(y + bar_height + conf.window_gap),
+		.x		= (int16_t)(usable.x + conf.window_gap),
+		.y		= (int16_t)(usable.y + conf.window_gap),
 		.width	= (uint16_t)(master_width - 2 * conf.window_gap),
-		.height = (uint16_t)(h - 2 * conf.window_gap - bar_height),
+		.height = (uint16_t)(usable.height - 2 * conf.window_gap),
 	};
 
 	/* stack rectangle */
 	const rectangle_t r2 = {
-		.x		= (int16_t)(x + master_width),
-		.y		= (int16_t)(y + bar_height + conf.window_gap),
+		.x		= (int16_t)(usable.x + master_width),
+		.y		= (int16_t)(usable.y + conf.window_gap),
 		.width	= (uint16_t)(r_width - (1 * conf.window_gap)),
-		.height = (uint16_t)(h - 2 * conf.window_gap - bar_height),
+		.height = (uint16_t)(usable.height - 2 * conf.window_gap),
 	};
 
 	/* if node is a root, give it full screen rectangle and ignore this
@@ -1360,10 +1348,10 @@ master_layout(node_t *root, node_t *n)
 	if (n->node_type == ROOT_NODE && n->first_child == NULL &&
 		n->second_child == NULL) {
 		n->rectangle = (rectangle_t){
-			.x		= (int16_t)(x + conf.window_gap),
-			.y		= (int16_t)(y + bar_height + conf.window_gap),
-			.width	= (uint16_t)(w - 2 * conf.window_gap),
-			.height = (uint16_t)(h - 2 * conf.window_gap - bar_height),
+			.x		= (int16_t)(usable.x + conf.window_gap),
+			.y		= (int16_t)(usable.y + conf.window_gap),
+			.width	= (uint16_t)(usable.width - 2 * conf.window_gap),
+			.height = (uint16_t)(usable.height - 2 * conf.window_gap),
 		};
 		return;
 	}

--- a/src/tree.c
+++ b/src/tree.c
@@ -825,6 +825,14 @@ restack(void)
 		window_above(c->window, p->window);
 	}
 
+	/* raise fullscreen windows above all*/
+	for (size_t i = 0; i < len; i++) {
+		client_t *c = v[i].c;
+		if (c && IS_FULLSCREEN(c)) {
+			raise_window(c->window);
+		}
+	}
+
 	/* publish _NET_CLIENT_LIST_STACKING */
 	xcb_window_t *stack = calloc(len, sizeof(*stack));
 	if (stack) {

--- a/src/type.h
+++ b/src/type.h
@@ -152,6 +152,13 @@ typedef struct {
 	uint16_t height;
 } rectangle_t;
 
+typedef struct {
+	int16_t top;
+	int16_t right;
+	int16_t bottom;
+	int16_t left;
+} padding_t;
+
 typedef enum {
 	TILED,	   /* automatically tiled */
 	FLOATING,  /* freely movable */
@@ -173,6 +180,7 @@ typedef enum {
 	WINDOW_TYPE_SPLASH		 = 5,
 	WINDOW_TYPE_DIALOG		 = 6,
 	WINDOW_TYPE_NOTIFICATION = 7,
+	WINDOW_TYPE_DESKTOP		 = 8,
 	WINDOW_TYPE_UNKNOWN		 = -1
 } ewmh_window_type_t;
 
@@ -314,6 +322,7 @@ struct monitor_t {
 	desktop_t		  *desk;		/* focused desktop */
 	monitor_t		  *next;		/* next monitor in list */
 	rectangle_t		   rectangle;	/* monitor dimensions */
+	padding_t		   padding;		/* EWMH strut padding */
 	xcb_randr_output_t randr_id;	/* randr output id, used with xrnadr */
 	xcb_window_t	   root;		/* the root window on this monitor */
 	uint32_t		   id;			/* monitor identifier, used with xinerama */
@@ -327,19 +336,11 @@ struct monitor_t {
 	bool			   is_primary;	  /* primary monitor */
 };
 
-/* status bar representation */
-typedef struct {
-	rectangle_t	 rectangle; /* bar dimensions */
-	xcb_window_t window;	/* xcb window reference */
-	uint32_t	 id;		/* bar identifier */
-} bar_t;
-
 /* window manager global state */
 typedef struct {
-	xcb_connection_t	  *connection; /* xcb connection */
-	xcb_ewmh_connection_t *ewmh;	   /* ewmh connection */
-	xcb_screen_t		  *screen;	   /* global screen */
-	bar_t				  *bar;		   /* status bar, should be moved (FIXME) */
+	xcb_connection_t	  *connection;	/* xcb connection */
+	xcb_ewmh_connection_t *ewmh;		/* ewmh connection */
+	xcb_screen_t		  *screen;		/* global screen */
 	xcb_window_t		   root_window; /* root window */
 	split_type_t		   split_type;	/* current split type */
 	uint8_t				   screen_nbr;	/* screen number */
@@ -433,6 +434,11 @@ typedef struct {
 	int16_t		 avail;
 	uint8_t		 edges;
 } mouse_state_t;
+
+typedef struct strut_window_node_t {
+	xcb_window_t				win;
+	struct strut_window_node_t *next;
+} strut_win_node_t;
 
 /* window rule structure (linked list) */
 typedef struct rule_t rule_t;

--- a/src/zwm.c
+++ b/src/zwm.c
@@ -1172,6 +1172,9 @@ set_fullscreen(node_t *n, bool flag)
 			move_window(n->client->window, r.x, r.y) != 0) {
 			return -1;
 		}
+		/* raise fullscreen window above all windows (including unmanaged
+		 * DOCKs)*/
+		raise_window(n->client->window);
 		xcb_cookie_t c	 = xcb_change_property_checked(wm->connection,
 													   XCB_PROP_MODE_REPLACE,
 													   n->client->window,

--- a/src/zwm.c
+++ b/src/zwm.c
@@ -1172,9 +1172,6 @@ set_fullscreen(node_t *n, bool flag)
 			move_window(n->client->window, r.x, r.y) != 0) {
 			return -1;
 		}
-		/* raise fullscreen window above all windows (including unmanaged
-		 * DOCKs)*/
-		raise_window(n->client->window);
 		xcb_cookie_t c	 = xcb_change_property_checked(wm->connection,
 													   XCB_PROP_MODE_REPLACE,
 													   n->client->window,

--- a/src/zwm.h
+++ b/src/zwm.h
@@ -40,6 +40,7 @@ extern xcb_window_t 	  focused_win;
 extern monitor_t 		  *head_monitor;
 extern monitor_t		  *prim_monitor;
 extern monitor_t 		  *curr_monitor;
+extern strut_win_node_t  *strut_windows;
 extern bool 			  using_xrandr;
 extern bool 		      using_xinerama;
 extern uint8_t 			  randr_base;
@@ -86,5 +87,12 @@ uint64_t stack_key(const client_t *c);
 ewmh_window_type_t window_type(xcb_window_t win);
 uint32_t get_next_mru_seq(monitor_t *monitor);
 monitor_t *get_monitor_by_window(xcb_window_t win);
+bool ewmh_handle_struts(xcb_window_t win);
+rectangle_t get_usable_area(monitor_t *m);
+void recalculate_all_struts(void);
+void add_strut_window(xcb_window_t win);
+bool remove_strut_window(xcb_window_t win);
+bool is_strut_window(xcb_window_t win);
+void cleanup_strut_windows(void);
 /* clang-format on */
 #endif /* ZWM_ZWM_H */


### PR DESCRIPTION
Fix protocol-level mismatches exposed by OBS by enforcing a single global
stacking order, and sending truthful ConfigureNotify geometry, and keeping EWMH
desktop/hidden state in sync. 